### PR TITLE
fix: improve 2.2.12 debug output legibility (stdout_lines list)

### DIFF
--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -594,4 +594,8 @@
 
     - name: "2.2.12 | AUDIT | Report listening services for manual review"
       ansible.builtin.debug:
-        msg: "2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:\n{{ cis_2_2_12_sockstat.stdout }}"
+        msg: >-
+          {{
+            ['2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:', '']
+            + cis_2_2_12_sockstat.stdout_lines
+          }}


### PR DESCRIPTION
## Summary
Replace the `stdout` string concatenation in 2.2.12's debug task with a list built from `stdout_lines`.

## Why
When `msg` is a plain string, Ansible renders the sockstat output as a single escaped blob — all rows collapsed with literal `\n` separators, as seen in the observed output. When `msg` is a list, Ansible debug prints each element on its own line, so the sockstat table renders as legible, properly-spaced rows.

## Change
`tasks/section_2.yml` — 2.2.12 AUDIT report task:
- Before: `msg: "2.2.12 MANUAL REVIEW... \n{{ cis_2_2_12_sockstat.stdout }}"`
- After: `msg` is a list of `['header', ''] + cis_2_2_12_sockstat.stdout_lines`

## Validation
- ansible-lint: passed (0 failures, production profile)

## Risks / follow-ups
None. Pure output formatting change — no behavioral change to audit logic or remediation.
