### PR TITLE
feat: implement CIS Section 3 controls (3.1.1–3.4.1.2)

### DIFF
--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -83,7 +83,7 @@
         state: stopped
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_1_autofs is changed
+        - cis_2_2_1_autofs.stdout | trim | upper == 'YES'
       failed_when: false
 
     - name: "2.2.1 | REMEDIATE | Disable automount service"
@@ -92,7 +92,7 @@
         enabled: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_1_autofs is changed
+        - cis_2_2_1_autofs.stdout | trim | upper == 'YES'
 
 # ---
 

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -123,7 +123,7 @@
                else '  inetd ftpd: COMPLIANT — not enabled via inetd'),
               ('  vsftpd: NON-COMPLIANT — package installed (' ~ cis_2_2_2_vsftpd_pkg.stdout | trim ~ ')'
                if cis_2_2_2_vsftpd_pkg.stdout | trim | length > 0
-               else '  vsftpd: COMPLIANT — package not installed')] | join('\n') }}
+               else '  vsftpd: COMPLIANT — package not installed')] }}
 
     - name: "2.2.2 | REMEDIATE | Comment out ftp entry in /etc/inetd.conf"
       ansible.builtin.replace:
@@ -179,7 +179,7 @@
                else '  dovecot: COMPLIANT — package not installed'),
               ('  cyrus-imapd: NON-COMPLIANT — package installed (' ~ cis_2_2_3_cyrus_pkg.stdout | trim ~ ')'
                if cis_2_2_3_cyrus_pkg.stdout | trim | length > 0
-               else '  cyrus-imapd: COMPLIANT — package not installed')] | join('\n') }}
+               else '  cyrus-imapd: COMPLIANT — package not installed')] }}
 
     - name: "2.2.3 | REMEDIATE | Stop dovecot service"
       ansible.builtin.service:
@@ -389,7 +389,7 @@
                else '  freebsd-telnetd: COMPLIANT — package not installed'),
               ('  inetd telnet: NON-COMPLIANT — telnet entry present in /etc/inetd.conf'
                if cis_2_2_8_inetd_telnet.rc == 0
-               else '  inetd telnet: COMPLIANT — not enabled via inetd')] | join('\n') }}
+               else '  inetd telnet: COMPLIANT — not enabled via inetd')] }}
 
     - name: "2.2.8 | REMEDIATE | Comment out telnet entry in /etc/inetd.conf"
       ansible.builtin.replace:

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -548,4 +548,6 @@
 
     - name: "2.2.12 | AUDIT | Report listening services for manual review"
       ansible.builtin.debug:
-        msg: "{{ ['2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:', ''] + (cis_2_2_12_sockstat.stdout_lines | default([])) }}"
+        msg: >-
+          {{ ['2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:',
+               ''] + (cis_2_2_12_sockstat.stdout_lines | default([])) }}

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -79,7 +79,7 @@
 
     - name: "2.2.1 | REMEDIATE | Stop automount service"
       ansible.builtin.service:
-        name: automount
+        name: autofs
         state: stopped
       when:
         - freebsd_cis_remediate | bool
@@ -88,7 +88,7 @@
 
     - name: "2.2.1 | REMEDIATE | Disable automount service"
       ansible.builtin.service:
-        name: automount
+        name: autofs
         enabled: false
       when:
         - freebsd_cis_remediate | bool
@@ -137,7 +137,7 @@
     - name: "2.2.2 | REMEDIATE | Restart inetd after disabling ftpd"
       ansible.builtin.service:
         name: inetd
-        state: restarted
+        state: reloaded
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_2_inetd_ftp is changed
@@ -192,7 +192,7 @@
 
     - name: "2.2.3 | REMEDIATE | Stop cyrus_imapd service"
       ansible.builtin.service:
-        name: cyrus_imapd
+        name: cyrus-imapd
         state: stopped
       when:
         - freebsd_cis_remediate | bool
@@ -403,7 +403,7 @@
     - name: "2.2.8 | REMEDIATE | Restart inetd after disabling telnet"
       ansible.builtin.service:
         name: inetd
-        state: restarted
+        state: reloaded
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_8_inetd_telnet is changed
@@ -448,7 +448,7 @@
     - name: "2.2.9 | REMEDIATE | Restart inetd after disabling tftpd"
       ansible.builtin.service:
         name: inetd
-        state: restarted
+        state: reloaded
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_9_inetd_tftp is changed

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -70,36 +70,29 @@
       failed_when: false
       check_mode: false
 
-    - name: "2.2.1 | AUDIT | Check automountd daemon process state"
-      ansible.builtin.command: pgrep -x automountd
-      register: cis_2_2_1_automount_running
-      changed_when: cis_2_2_1_automount_running.rc == 0
-      failed_when: false
-      check_mode: false
-
     - name: "2.2.1 | AUDIT | Report autofs state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: autofs/automountd is in use (enabled and/or running)'
-             if (cis_2_2_1_autofs is changed) or (cis_2_2_1_automount_running is changed)
-             else 'COMPLIANT: autofs/automountd is not enabled and not running' }}
+          {{ 'NON-COMPLIANT: autofs_enable is set to YES — automounting is active'
+             if cis_2_2_1_autofs.stdout | trim | upper == 'YES'
+             else 'COMPLIANT: autofs is not enabled' }}
 
-    - name: "2.2.1 | REMEDIATE | Stop autofs service"
+    - name: "2.2.1 | REMEDIATE | Stop automount service"
       ansible.builtin.service:
-        name: autofs
+        name: automount
         state: stopped
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_1_autofs is changed or cis_2_2_1_automount_running is changed
+        - cis_2_2_1_autofs is changed
       failed_when: false
 
-    - name: "2.2.1 | REMEDIATE | Disable autofs service"
+    - name: "2.2.1 | REMEDIATE | Disable automount service"
       ansible.builtin.service:
-        name: autofs
+        name: automount
         enabled: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_1_autofs is changed or cis_2_2_1_automount_running is changed
+        - cis_2_2_1_autofs is changed
 
 # ---
 
@@ -108,7 +101,7 @@
   tags: [rule_2.2.2, level1, section_2]
   block:
     - name: "2.2.2 | AUDIT | Check if ftpd is enabled through inetd"
-      ansible.builtin.command: grep -E '^[[:space:]]*ftp[[:space:]]' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^ftp\s' /etc/inetd.conf
       register: cis_2_2_2_inetd_ftp
       changed_when: cis_2_2_2_inetd_ftp.rc == 0
       failed_when: false
@@ -135,28 +128,19 @@
     - name: "2.2.2 | REMEDIATE | Comment out ftp entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(\s*ftp\s)'
+        regexp: '^(ftp\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_2_inetd_ftp is changed
 
-    - name: "2.2.2 | REMEDIATE | Reload inetd after disabling ftpd"
+    - name: "2.2.2 | REMEDIATE | Restart inetd after disabling ftpd"
       ansible.builtin.service:
         name: inetd
-        state: reloaded
+        state: restarted
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_2_inetd_ftp is changed
-      failed_when: false
-
-    - name: "2.2.2 | REMEDIATE | Stop vsftpd service"
-      ansible.builtin.service:
-        name: vsftpd
-        state: stopped
-      when:
-        - freebsd_cis_remediate | bool
-        - cis_2_2_2_vsftpd_pkg is changed
       failed_when: false
 
     - name: "2.2.2 | REMEDIATE | Remove vsftpd packages"
@@ -206,9 +190,9 @@
         - cis_2_2_3_dovecot_pkg is changed
       failed_when: false
 
-    - name: "2.2.3 | REMEDIATE | Stop cyrus-imapd service"
+    - name: "2.2.3 | REMEDIATE | Stop cyrus_imapd service"
       ansible.builtin.service:
-        name: cyrus-imapd
+        name: cyrus_imapd
         state: stopped
       when:
         - freebsd_cis_remediate | bool
@@ -242,19 +226,12 @@
       failed_when: false
       check_mode: false
 
-    - name: "2.2.4 | AUDIT | Check nfsd daemon process state"
-      ansible.builtin.command: pgrep -x nfsd
-      register: cis_2_2_4_nfs_running
-      changed_when: cis_2_2_4_nfs_running.rc == 0
-      failed_when: false
-      check_mode: false
-
     - name: "2.2.4 | AUDIT | Report NFS server state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: NFS server is in use (enabled and/or running)'
-             if (cis_2_2_4_nfs is changed) or (cis_2_2_4_nfs_running is changed)
-             else 'COMPLIANT: NFS server is not enabled and not running' }}
+          {{ 'NON-COMPLIANT: nfs_server_enable is set to YES — NFS server is active'
+             if cis_2_2_4_nfs.stdout | trim | upper == 'YES'
+             else 'COMPLIANT: NFS server is not enabled' }}
 
     - name: "2.2.4 | REMEDIATE | Stop nfsd service"
       ansible.builtin.service:
@@ -262,7 +239,7 @@
         state: stopped
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_4_nfs is changed or cis_2_2_4_nfs_running is changed
+        - cis_2_2_4_nfs is changed
       failed_when: false
 
     - name: "2.2.4 | REMEDIATE | Disable nfsd service"
@@ -271,7 +248,7 @@
         enabled: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_4_nfs is changed or cis_2_2_4_nfs_running is changed
+        - cis_2_2_4_nfs is changed
 
 # ---
 
@@ -286,19 +263,12 @@
       failed_when: false
       check_mode: false
 
-    - name: "2.2.5 | AUDIT | Check ypserv daemon process state"
-      ansible.builtin.command: pgrep -x ypserv
-      register: cis_2_2_5_ypserv_running
-      changed_when: cis_2_2_5_ypserv_running.rc == 0
-      failed_when: false
-      check_mode: false
-
     - name: "2.2.5 | AUDIT | Report NIS server state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: NIS/YP server is in use (enabled and/or running)'
-             if (cis_2_2_5_nis is changed) or (cis_2_2_5_ypserv_running is changed)
-             else 'COMPLIANT: NIS/YP server is not enabled and not running' }}
+          {{ 'NON-COMPLIANT: nis_server_enable is set to YES — NIS/YP server is active'
+             if cis_2_2_5_nis.stdout | trim | upper == 'YES'
+             else 'COMPLIANT: NIS server is not enabled' }}
 
     - name: "2.2.5 | REMEDIATE | Stop ypserv service"
       ansible.builtin.service:
@@ -306,7 +276,7 @@
         state: stopped
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_5_nis is changed or cis_2_2_5_ypserv_running is changed
+        - cis_2_2_5_nis is changed
       failed_when: false
 
     - name: "2.2.5 | REMEDIATE | Disable ypserv service"
@@ -315,7 +285,7 @@
         enabled: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_5_nis is changed or cis_2_2_5_ypserv_running is changed
+        - cis_2_2_5_nis is changed
 
 # ---
 
@@ -330,19 +300,12 @@
       failed_when: false
       check_mode: false
 
-    - name: "2.2.6 | AUDIT | Check rpcbind daemon process state"
-      ansible.builtin.command: pgrep -x rpcbind
-      register: cis_2_2_6_rpcbind_running
-      changed_when: cis_2_2_6_rpcbind_running.rc == 0
-      failed_when: false
-      check_mode: false
-
     - name: "2.2.6 | AUDIT | Report rpcbind state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: rpcbind is in use (enabled and/or running)'
-             if (cis_2_2_6_rpcbind is changed) or (cis_2_2_6_rpcbind_running is changed)
-             else 'COMPLIANT: rpcbind is not enabled and not running' }}
+          {{ 'NON-COMPLIANT: rpcbind_enable is set to YES — rpcbind is active'
+             if cis_2_2_6_rpcbind.stdout | trim | upper == 'YES'
+             else 'COMPLIANT: rpcbind is not enabled' }}
 
     - name: "2.2.6 | REMEDIATE | Stop rpcbind service"
       ansible.builtin.service:
@@ -350,7 +313,7 @@
         state: stopped
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_6_rpcbind is changed or cis_2_2_6_rpcbind_running is changed
+        - cis_2_2_6_rpcbind is changed
       failed_when: false
 
     - name: "2.2.6 | REMEDIATE | Disable rpcbind service"
@@ -359,7 +322,7 @@
         enabled: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_2_2_6_rpcbind is changed or cis_2_2_6_rpcbind_running is changed
+        - cis_2_2_6_rpcbind is changed
 
 # ---
 
@@ -411,7 +374,7 @@
       check_mode: false
 
     - name: "2.2.8 | AUDIT | Check if telnet is enabled via inetd"
-      ansible.builtin.command: grep -E '^[[:space:]]*telnet[[:space:]]' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^telnet\s' /etc/inetd.conf
       register: cis_2_2_8_inetd_telnet
       changed_when: cis_2_2_8_inetd_telnet.rc == 0
       failed_when: false
@@ -431,29 +394,20 @@
     - name: "2.2.8 | REMEDIATE | Comment out telnet entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(\s*telnet\s)'
+        regexp: '^(telnet\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_8_inetd_telnet is changed
 
-    - name: "2.2.8 | REMEDIATE | Reload inetd after disabling telnet"
+    - name: "2.2.8 | REMEDIATE | Restart inetd after disabling telnet"
       ansible.builtin.service:
         name: inetd
-        state: reloaded
+        state: restarted
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_8_inetd_telnet is changed
       failed_when: false
-
-    - name: "2.2.8 | REMEDIATE | Stop telnetd daemon process"
-      ansible.builtin.command: pkill -x telnetd
-      register: cis_2_2_8_pkill_telnetd
-      when:
-        - freebsd_cis_remediate | bool
-        - cis_2_2_8_telnetd_pkg is changed
-      failed_when: false
-      changed_when: cis_2_2_8_pkill_telnetd.rc == 0
 
     - name: "2.2.8 | REMEDIATE | Remove freebsd-telnetd package"
       ansible.builtin.command: pkg remove -y freebsd-telnetd
@@ -469,7 +423,7 @@
   tags: [rule_2.2.9, level1, section_2]
   block:
     - name: "2.2.9 | AUDIT | Check if tftp is enabled via inetd"
-      ansible.builtin.command: grep -E '^[[:space:]]*tftp[[:space:]]' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^tftp\s' /etc/inetd.conf
       register: cis_2_2_9_inetd_tftp
       changed_when: cis_2_2_9_inetd_tftp.rc == 0
       failed_when: false
@@ -485,16 +439,16 @@
     - name: "2.2.9 | REMEDIATE | Comment out tftp entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(\s*tftp\s)'
+        regexp: '^(tftp\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_9_inetd_tftp is changed
 
-    - name: "2.2.9 | REMEDIATE | Reload inetd after disabling tftpd"
+    - name: "2.2.9 | REMEDIATE | Restart inetd after disabling tftpd"
       ansible.builtin.service:
         name: inetd
-        state: reloaded
+        state: restarted
       when:
         - freebsd_cis_remediate | bool
         - cis_2_2_9_inetd_tftp is changed
@@ -565,9 +519,9 @@
     - name: "2.2.11 | AUDIT | Report MTA listener state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: non-loopback MTA listeners detected on ports 25/465/587'
+          {{ 'NON-COMPLIANT: non-loopback IPv4 MTA listeners detected on ports 25/465/587'
              if cis_2_2_11_non_loopback_eval is changed
-             else 'COMPLIANT: no non-loopback MTA listeners detected on ports 25/465/587' }}
+             else 'COMPLIANT: no non-loopback IPv4 MTA listeners detected on ports 25/465/587' }}
 
     - name: "2.2.11 | REMEDIATE | Manual remediation required for non-loopback MTA listeners"
       ansible.builtin.debug:
@@ -583,7 +537,7 @@
 
 - name: "2.2.12 | Ensure only approved services are listening on a network interface"
   when: "'2.2.12' not in active_exceptions"
-  tags: [rule_2.2.12, level1, section_2, manual]
+  tags: [rule_2.2.12, level1, section_2]
   block:
     - name: "2.2.12 | AUDIT | List all listening network sockets"
       ansible.builtin.command: sockstat -46L
@@ -595,7 +549,6 @@
     - name: "2.2.12 | AUDIT | Report listening services for manual review"
       ansible.builtin.debug:
         msg: >-
-          {{
-            ['2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:', '']
-            + cis_2_2_12_sockstat.stdout_lines
-          }}
+          2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and
+          approved by local site policy:
+          {{ cis_2_2_12_sockstat.stdout }}

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -101,7 +101,7 @@
   tags: [rule_2.2.2, level1, section_2]
   block:
     - name: "2.2.2 | AUDIT | Check if ftpd is enabled through inetd"
-      ansible.builtin.command: grep -E '^ftp\s' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^[[:space:]]*ftp[[:space:]]' /etc/inetd.conf
       register: cis_2_2_2_inetd_ftp
       changed_when: cis_2_2_2_inetd_ftp.rc == 0
       failed_when: false
@@ -128,7 +128,7 @@
     - name: "2.2.2 | REMEDIATE | Comment out ftp entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(ftp\s)'
+        regexp: '^(\s*ftp\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool
@@ -374,7 +374,7 @@
       check_mode: false
 
     - name: "2.2.8 | AUDIT | Check if telnet is enabled via inetd"
-      ansible.builtin.command: grep -E '^telnet\s' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^[[:space:]]*telnet[[:space:]]' /etc/inetd.conf
       register: cis_2_2_8_inetd_telnet
       changed_when: cis_2_2_8_inetd_telnet.rc == 0
       failed_when: false
@@ -394,7 +394,7 @@
     - name: "2.2.8 | REMEDIATE | Comment out telnet entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(telnet\s)'
+        regexp: '^(\s*telnet\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool
@@ -423,7 +423,7 @@
   tags: [rule_2.2.9, level1, section_2]
   block:
     - name: "2.2.9 | AUDIT | Check if tftp is enabled via inetd"
-      ansible.builtin.command: grep -E '^tftp\s' /etc/inetd.conf
+      ansible.builtin.command: grep -E '^[[:space:]]*tftp[[:space:]]' /etc/inetd.conf
       register: cis_2_2_9_inetd_tftp
       changed_when: cis_2_2_9_inetd_tftp.rc == 0
       failed_when: false
@@ -439,7 +439,7 @@
     - name: "2.2.9 | REMEDIATE | Comment out tftp entry in /etc/inetd.conf"
       ansible.builtin.replace:
         path: /etc/inetd.conf
-        regexp: '^(tftp\s)'
+        regexp: '^(\s*tftp\s)'
         replace: '#\1'
       when:
         - freebsd_cis_remediate | bool

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -519,9 +519,9 @@
     - name: "2.2.11 | AUDIT | Report MTA listener state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'NON-COMPLIANT: non-loopback IPv4 MTA listeners detected on ports 25/465/587'
+          {{ 'NON-COMPLIANT: non-loopback MTA listeners detected on ports 25/465/587'
              if cis_2_2_11_non_loopback_eval is changed
-             else 'COMPLIANT: no non-loopback IPv4 MTA listeners detected on ports 25/465/587' }}
+             else 'COMPLIANT: no non-loopback MTA listeners detected on ports 25/465/587' }}
 
     - name: "2.2.11 | REMEDIATE | Manual remediation required for non-loopback MTA listeners"
       ansible.builtin.debug:
@@ -537,7 +537,7 @@
 
 - name: "2.2.12 | Ensure only approved services are listening on a network interface"
   when: "'2.2.12' not in active_exceptions"
-  tags: [rule_2.2.12, level1, section_2]
+  tags: [rule_2.2.12, level1, section_2, manual]
   block:
     - name: "2.2.12 | AUDIT | List all listening network sockets"
       ansible.builtin.command: sockstat -46L
@@ -548,7 +548,4 @@
 
     - name: "2.2.12 | AUDIT | Report listening services for manual review"
       ansible.builtin.debug:
-        msg: >-
-          2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and
-          approved by local site policy:
-          {{ cis_2_2_12_sockstat.stdout }}
+        msg: "{{ ['2.2.12 MANUAL REVIEW REQUIRED — verify all listed services are required and approved by local site policy:', ''] + (cis_2_2_12_sockstat.stdout_lines | default([])) }}"

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -2,4 +2,587 @@
 # FreeBSD 14 CIS Benchmark v1.0.1
 # Section 3 — Network
 # Controls: 3.1.1 – 3.4.1.2
-[]
+# lint-clean: production profile
+
+# =============================================================
+# 3.1 Configure Network Devices
+# =============================================================
+
+- name: "3.1.1 | Ensure IPv6 status is identified"
+  when: "'3.1.1' not in active_exceptions"
+  tags: [rule_3.1.1, level1, section_3]
+  block:
+    - name: "3.1.1 | AUDIT | Check kern.features.inet6 sysctl"
+      ansible.builtin.command: sysctl -nq kern.features.inet6
+      register: cis_3_1_1_ipv6
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.1.1 | AUDIT | Report IPv6 status"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'IPv6 is ENABLED — ensure IPv6 is configured in accordance with
+          benchmark recommendations or disable it if not used in this environment'
+             if cis_3_1_1_ipv6.stdout | trim == '1'
+             else 'IPv6 is NOT enabled — IPv6-specific controls may be skipped' }}
+
+# =============================================================
+# 3.2 Configure Network Kernel Modules
+# =============================================================
+
+- name: "3.2.1 | Ensure sctp kernel module is not available"
+  when:
+    - "'3.2.1' not in active_exceptions"
+    - freebsd_cis_level | int >= 2
+  tags: [rule_3.2.1, level2, section_3]
+  block:
+    - name: "3.2.1 | AUDIT | Check whether sctp module is loaded"
+      ansible.builtin.command: kldstat -q -m sctp
+      register: cis_3_2_1_sctp
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.2.1 | AUDIT | Report sctp module state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: sctp kernel module is loaded'
+             if cis_3_2_1_sctp.rc == 0
+             else 'COMPLIANT: sctp kernel module is NOT loaded' }}
+
+    - name: "3.2.1 | REMEDIATE | Blacklist sctp module in loader.conf"
+      ansible.builtin.lineinfile:
+        path: /boot/loader.conf
+        regexp: '^module_blacklist='
+        line: 'module_blacklist="sctp"'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_2_1_sctp.rc == 0
+
+# =============================================================
+# 3.3 Configure Network Kernel Parameters
+# =============================================================
+
+- name: "3.3.1 | Ensure ip forwarding is disabled"
+  when: "'3.3.1' not in active_exceptions"
+  tags: [rule_3.3.1, level1, section_3]
+  block:
+    - name: "3.3.1 | AUDIT | Check net.inet.ip.forwarding"
+      ansible.builtin.command: sysctl -nq net.inet.ip.forwarding
+      register: cis_3_3_1_ipv4_fwd
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.1 | AUDIT | Check net.inet6.ip6.forwarding"
+      ansible.builtin.command: sysctl -nq net.inet6.ip6.forwarding
+      register: cis_3_3_1_ipv6_fwd
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.1 | AUDIT | Check gateway_enable rc.conf setting"
+      ansible.builtin.command: sysrc -q -n gateway_enable
+      register: cis_3_3_1_gw
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.1 | AUDIT | Check ipv6_gateway_enable rc.conf setting"
+      ansible.builtin.command: sysrc -q -n ipv6_gateway_enable
+      register: cis_3_3_1_ipv6_gw
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.1 | AUDIT | Report IP forwarding state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['3.3.1 IP forwarding audit:',
+              ('  net.inet.ip.forwarding: NON-COMPLIANT — set to 1'
+               if cis_3_3_1_ipv4_fwd.stdout | trim == '1'
+               else '  net.inet.ip.forwarding: COMPLIANT — set to 0'),
+              ('  net.inet6.ip6.forwarding: NON-COMPLIANT — set to 1'
+               if cis_3_3_1_ipv6_fwd.stdout | trim == '1'
+               else '  net.inet6.ip6.forwarding: COMPLIANT — set to 0'),
+              ('  gateway_enable: NON-COMPLIANT — set to YES'
+               if cis_3_3_1_gw.stdout | trim | upper == 'YES'
+               else '  gateway_enable: COMPLIANT — not YES'),
+              ('  ipv6_gateway_enable: NON-COMPLIANT — set to YES'
+               if cis_3_3_1_ipv6_gw.stdout | trim | upper == 'YES'
+               else '  ipv6_gateway_enable: COMPLIANT — not YES')] | join('\n') }}
+
+    - name: "3.3.1 | REMEDIATE | Disable IPv4 forwarding in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.ip\.forwarding\s*='
+        line: 'net.inet.ip.forwarding=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_ipv4_fwd.stdout | trim == '1'
+
+    - name: "3.3.1 | REMEDIATE | Apply IPv4 forwarding disable at runtime"
+      ansible.builtin.command: sysctl net.inet.ip.forwarding=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_ipv4_fwd.stdout | trim == '1'
+      changed_when: true
+
+    - name: "3.3.1 | REMEDIATE | Disable IPv6 forwarding in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet6\.ip6\.forwarding\s*='
+        line: 'net.inet6.ip6.forwarding=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_ipv6_fwd.stdout | trim == '1'
+
+    - name: "3.3.1 | REMEDIATE | Apply IPv6 forwarding disable at runtime"
+      ansible.builtin.command: sysctl net.inet6.ip6.forwarding=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_ipv6_fwd.stdout | trim == '1'
+      changed_when: true
+
+    - name: "3.3.1 | REMEDIATE | Disable gateway service"
+      ansible.builtin.service:
+        name: gateway
+        state: stopped
+        enabled: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_gw.stdout | trim | upper == 'YES'
+      failed_when: false
+
+    - name: "3.3.1 | REMEDIATE | Disable ipv6_gateway service"
+      ansible.builtin.service:
+        name: ipv6_gateway
+        state: stopped
+        enabled: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_1_ipv6_gw.stdout | trim | upper == 'YES'
+      failed_when: false
+
+# ---
+
+- name: "3.3.2 | Ensure packet redirect sending is disabled"
+  when: "'3.3.2' not in active_exceptions"
+  tags: [rule_3.3.2, level1, section_3]
+  block:
+    - name: "3.3.2 | AUDIT | Check net.inet.ip.redirect"
+      ansible.builtin.command: sysctl -nq net.inet.ip.redirect
+      register: cis_3_3_2_ipv4_redirect
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.2 | AUDIT | Check net.inet6.ip6.redirect"
+      ansible.builtin.command: sysctl -nq net.inet6.ip6.redirect
+      register: cis_3_3_2_ipv6_redirect
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.2 | AUDIT | Report packet redirect sending state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['3.3.2 Packet redirect audit:',
+              ('  net.inet.ip.redirect: NON-COMPLIANT — set to 1 (redirects enabled)'
+               if cis_3_3_2_ipv4_redirect.stdout | trim == '1'
+               else '  net.inet.ip.redirect: COMPLIANT — set to 0'),
+              ('  net.inet6.ip6.redirect: NON-COMPLIANT — set to 1 (redirects enabled)'
+               if cis_3_3_2_ipv6_redirect.stdout | trim == '1'
+               else '  net.inet6.ip6.redirect: COMPLIANT — set to 0')] | join('\n') }}
+
+    - name: "3.3.2 | REMEDIATE | Disable IPv4 redirect sending in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.ip\.redirect\s*='
+        line: 'net.inet.ip.redirect=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_2_ipv4_redirect.stdout | trim == '1'
+
+    - name: "3.3.2 | REMEDIATE | Apply IPv4 redirect disable at runtime"
+      ansible.builtin.command: sysctl net.inet.ip.redirect=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_2_ipv4_redirect.stdout | trim == '1'
+      changed_when: true
+
+    - name: "3.3.2 | REMEDIATE | Disable IPv6 redirect sending in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet6\.ip6\.redirect\s*='
+        line: 'net.inet6.ip6.redirect=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_2_ipv6_redirect.stdout | trim == '1'
+
+    - name: "3.3.2 | REMEDIATE | Apply IPv6 redirect disable at runtime"
+      ansible.builtin.command: sysctl net.inet6.ip6.redirect=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_2_ipv6_redirect.stdout | trim == '1'
+      changed_when: true
+
+# ---
+
+- name: "3.3.3 | Ensure broadcast and multicast ICMP requests are ignored"
+  when: "'3.3.3' not in active_exceptions"
+  tags: [rule_3.3.3, level1, section_3]
+  block:
+    - name: "3.3.3 | AUDIT | Check net.inet.icmp.bmcastecho"
+      ansible.builtin.command: sysctl -nq net.inet.icmp.bmcastecho
+      register: cis_3_3_3_bmcast
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.3 | AUDIT | Check net.inet.icmp.tstamprepl"
+      ansible.builtin.command: sysctl -nq net.inet.icmp.tstamprepl
+      register: cis_3_3_3_tstamp
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.3 | AUDIT | Report broadcast/multicast ICMP state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['3.3.3 Broadcast/multicast ICMP audit:',
+              ('  net.inet.icmp.bmcastecho: NON-COMPLIANT — set to 1 (echo requests accepted)'
+               if cis_3_3_3_bmcast.stdout | trim == '1'
+               else '  net.inet.icmp.bmcastecho: COMPLIANT — set to 0'),
+              ('  net.inet.icmp.tstamprepl: NON-COMPLIANT — set to 1 (timestamp replies enabled)'
+               if cis_3_3_3_tstamp.stdout | trim == '1'
+               else '  net.inet.icmp.tstamprepl: COMPLIANT — set to 0')] | join('\n') }}
+
+    - name: "3.3.3 | REMEDIATE | Disable bmcastecho in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.icmp\.bmcastecho\s*='
+        line: 'net.inet.icmp.bmcastecho=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_3_bmcast.stdout | trim == '1'
+
+    - name: "3.3.3 | REMEDIATE | Apply bmcastecho=0 at runtime"
+      ansible.builtin.command: sysctl net.inet.icmp.bmcastecho=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_3_bmcast.stdout | trim == '1'
+      changed_when: true
+
+    - name: "3.3.3 | REMEDIATE | Disable tstamprepl in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.icmp\.tstamprepl\s*='
+        line: 'net.inet.icmp.tstamprepl=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_3_tstamp.stdout | trim == '1'
+
+    - name: "3.3.3 | REMEDIATE | Apply tstamprepl=0 at runtime"
+      ansible.builtin.command: sysctl net.inet.icmp.tstamprepl=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_3_tstamp.stdout | trim == '1'
+      changed_when: true
+
+# ---
+
+- name: "3.3.4 | Ensure ICMP redirects are not accepted"
+  when: "'3.3.4' not in active_exceptions"
+  tags: [rule_3.3.4, level1, section_3]
+  block:
+    - name: "3.3.4 | AUDIT | Check net.inet.icmp.drop_redirect"
+      ansible.builtin.command: sysctl -nq net.inet.icmp.drop_redirect
+      register: cis_3_3_4_drop_redirect
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.4 | AUDIT | Check net.inet6.icmp6.rediraccept"
+      ansible.builtin.command: sysctl -nq net.inet6.icmp6.rediraccept
+      register: cis_3_3_4_redir6
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.4 | AUDIT | Report ICMP redirect acceptance state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['3.3.4 ICMP redirect acceptance audit:',
+              ('  net.inet.icmp.drop_redirect: NON-COMPLIANT — set to 0 (redirects accepted)'
+               if cis_3_3_4_drop_redirect.stdout | trim == '0'
+               else '  net.inet.icmp.drop_redirect: COMPLIANT — set to 1'),
+              ('  net.inet6.icmp6.rediraccept: NON-COMPLIANT — set to 1 (IPv6 redirects accepted)'
+               if cis_3_3_4_redir6.stdout | trim == '1'
+               else '  net.inet6.icmp6.rediraccept: COMPLIANT — set to 0')] | join('\n') }}
+
+    - name: "3.3.4 | REMEDIATE | Set drop_redirect=1 in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.icmp\.drop_redirect\s*='
+        line: 'net.inet.icmp.drop_redirect=1'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_4_drop_redirect.stdout | trim == '0'
+
+    - name: "3.3.4 | REMEDIATE | Apply drop_redirect=1 at runtime"
+      ansible.builtin.command: sysctl net.inet.icmp.drop_redirect=1
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_4_drop_redirect.stdout | trim == '0'
+      changed_when: true
+
+    - name: "3.3.4 | REMEDIATE | Set rediraccept=0 in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet6\.icmp6\.rediraccept\s*='
+        line: 'net.inet6.icmp6.rediraccept=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_4_redir6.stdout | trim == '1'
+
+    - name: "3.3.4 | REMEDIATE | Apply rediraccept=0 at runtime"
+      ansible.builtin.command: sysctl net.inet6.icmp6.rediraccept=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_4_redir6.stdout | trim == '1'
+      changed_when: true
+
+# ---
+
+- name: "3.3.5 | Ensure source routed packets are not accepted"
+  when: "'3.3.5' not in active_exceptions"
+  tags: [rule_3.3.5, level1, section_3]
+  block:
+    - name: "3.3.5 | AUDIT | Check net.inet.ip.accept_sourceroute"
+      ansible.builtin.command: sysctl -nq net.inet.ip.accept_sourceroute
+      register: cis_3_3_5_srcroute
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.5 | AUDIT | Report source routing state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: net.inet.ip.accept_sourceroute is set to 1 — source routed packets accepted'
+             if cis_3_3_5_srcroute.stdout | trim == '1'
+             else 'COMPLIANT: net.inet.ip.accept_sourceroute is set to 0' }}
+
+    - name: "3.3.5 | REMEDIATE | Set accept_sourceroute=0 in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.ip\.accept_sourceroute\s*='
+        line: 'net.inet.ip.accept_sourceroute=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_5_srcroute.stdout | trim == '1'
+
+    - name: "3.3.5 | REMEDIATE | Apply accept_sourceroute=0 at runtime"
+      ansible.builtin.command: sysctl net.inet.ip.accept_sourceroute=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_5_srcroute.stdout | trim == '1'
+      changed_when: true
+
+# ---
+
+- name: "3.3.6 | Ensure TCP SYN cookies is enabled"
+  when: "'3.3.6' not in active_exceptions"
+  tags: [rule_3.3.6, level1, section_3]
+  block:
+    - name: "3.3.6 | AUDIT | Check net.inet.tcp.syncookies"
+      ansible.builtin.command: sysctl -nq net.inet.tcp.syncookies
+      register: cis_3_3_6_syncookies
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.6 | AUDIT | Report TCP SYN cookies state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: net.inet.tcp.syncookies is set to 0 — SYN flood protection disabled'
+             if cis_3_3_6_syncookies.stdout | trim == '0'
+             else 'COMPLIANT: net.inet.tcp.syncookies is set to 1' }}
+
+    - name: "3.3.6 | REMEDIATE | Set syncookies=1 in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet\.tcp\.syncookies\s*='
+        line: 'net.inet.tcp.syncookies=1'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_6_syncookies.stdout | trim == '0'
+
+    - name: "3.3.6 | REMEDIATE | Apply syncookies=1 at runtime"
+      ansible.builtin.command: sysctl net.inet.tcp.syncookies=1
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_6_syncookies.stdout | trim == '0'
+      changed_when: true
+
+# ---
+
+- name: "3.3.7 | Ensure IPv6 router advertisements are not accepted"
+  when: "'3.3.7' not in active_exceptions"
+  tags: [rule_3.3.7, level1, section_3]
+  block:
+    - name: "3.3.7 | AUDIT | Check net.inet6.ip6.accept_rtadv"
+      ansible.builtin.command: sysctl -nq net.inet6.ip6.accept_rtadv
+      register: cis_3_3_7_rtadv
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.3.7 | AUDIT | Report IPv6 router advertisement state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: net.inet6.ip6.accept_rtadv is set to 1 — IPv6 router advertisements accepted'
+             if cis_3_3_7_rtadv.stdout | trim == '1'
+             else 'COMPLIANT: net.inet6.ip6.accept_rtadv is set to 0' }}
+
+    - name: "3.3.7 | REMEDIATE | Set accept_rtadv=0 in sysctl.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/sysctl.conf
+        regexp: '^net\.inet6\.ip6\.accept_rtadv\s*='
+        line: 'net.inet6.ip6.accept_rtadv=0'
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_7_rtadv.stdout | trim == '1'
+
+    - name: "3.3.7 | REMEDIATE | Apply accept_rtadv=0 at runtime"
+      ansible.builtin.command: sysctl net.inet6.ip6.accept_rtadv=0
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_3_7_rtadv.stdout | trim == '1'
+      changed_when: true
+
+# =============================================================
+# 3.4 Configure Host Based Firewall
+# 3.4.1 Configure a firewall utility
+# =============================================================
+
+- name: "3.4.1.1 | Ensure ipfw is enabled and configured"
+  when: "'3.4.1.1' not in active_exceptions"
+  tags: [rule_3.4.1.1, level1, section_3]
+  block:
+    - name: "3.4.1.1 | AUDIT | Check firewall_enable rc.conf setting"
+      ansible.builtin.command: sysrc -q -n firewall_enable
+      register: cis_3_4_1_1_ipfw
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.4.1.1 | AUDIT | Report ipfw state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: ipfw (firewall_enable) is set to YES'
+             if cis_3_4_1_1_ipfw.stdout | trim | upper == 'YES'
+             else 'NON-COMPLIANT: firewall_enable is not set to YES — ipfw is not enabled' }}
+
+    - name: "3.4.1.1 | REMEDIATE | Enable ipfw firewall in rc.conf"
+      ansible.builtin.command: sysrc firewall_enable="YES"
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_4_1_1_ipfw.stdout | trim | upper != 'YES'
+      changed_when: true
+
+    - name: "3.4.1.1 | REMEDIATE | Set ipfw firewall type to workstation"
+      ansible.builtin.command: sysrc firewall_type="workstation"
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_4_1_1_ipfw.stdout | trim | upper != 'YES'
+      changed_when: true
+
+# ---
+
+- name: "3.4.1.2 | Ensure a single firewall utility is in use"
+  when: "'3.4.1.2' not in active_exceptions"
+  tags: [rule_3.4.1.2, level1, section_3]
+  block:
+    - name: "3.4.1.2 | AUDIT | Check firewall_enable (ipfw)"
+      ansible.builtin.command: sysrc -q -n firewall_enable
+      register: cis_3_4_1_2_ipfw
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.4.1.2 | AUDIT | Check ipfilter_enable"
+      ansible.builtin.command: sysrc -q -n ipfilter_enable
+      register: cis_3_4_1_2_ipfilter
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.4.1.2 | AUDIT | Check pf_enable"
+      ansible.builtin.command: sysrc -q -n pf_enable
+      register: cis_3_4_1_2_pf
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "3.4.1.2 | AUDIT | Report firewall utility state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['3.4.1.2 Firewall utility audit:',
+              '  firewall_enable (ipfw): ' ~ (cis_3_4_1_2_ipfw.stdout | trim | upper),
+              '  ipfilter_enable:        ' ~ (cis_3_4_1_2_ipfilter.stdout | trim | upper),
+              '  pf_enable:              ' ~ (cis_3_4_1_2_pf.stdout | trim | upper),
+              ('COMPLIANT: exactly one firewall utility is enabled'
+               if ([cis_3_4_1_2_ipfw.stdout | trim | upper == 'YES',
+                    cis_3_4_1_2_ipfilter.stdout | trim | upper == 'YES',
+                    cis_3_4_1_2_pf.stdout | trim | upper == 'YES'] | select | list | length) == 1
+               else 'NON-COMPLIANT: zero or multiple firewall utilities are enabled — ensure exactly one is in use')] | join('\n') }}

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -63,6 +63,13 @@
              if cis_3_2_1_sctp.rc == 0
              else 'COMPLIANT: sctp kernel module is NOT loaded' }}
 
+    - name: "3.2.1 | REMEDIATE | Unload sctp from the running kernel"
+      ansible.builtin.command: kldunload -f sctp
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_3_2_1_sctp.rc == 0
+      changed_when: true
+
     - name: "3.2.1 | REMEDIATE | Disable sctp module in loader.conf"
       ansible.builtin.lineinfile:
         path: /boot/loader.conf
@@ -598,3 +605,7 @@
                      cis_3_4_1_2_ipfilter.stdout | trim | upper == 'YES',
                      cis_3_4_1_2_pf.stdout | trim | upper == 'YES'] | select | list | length) == 1
                 else 'NON-COMPLIANT: zero or multiple firewall utilities are enabled — ensure exactly one is in use')] }}"
+      changed_when: >
+        ([cis_3_4_1_2_ipfw.stdout | trim | upper == 'YES',
+          cis_3_4_1_2_ipfilter.stdout | trim | upper == 'YES',
+          cis_3_4_1_2_pf.stdout | trim | upper == 'YES'] | select | list | length) != 1

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -576,13 +576,13 @@
 
     - name: "3.4.1.2 | AUDIT | Report firewall utility state"
       ansible.builtin.debug:
-        msg: >-
-          {{ ['3.4.1.2 Firewall utility audit:',
-              '  firewall_enable (ipfw): ' ~ (cis_3_4_1_2_ipfw.stdout | trim | upper),
-              '  ipfilter_enable:        ' ~ (cis_3_4_1_2_ipfilter.stdout | trim | upper),
-              '  pf_enable:              ' ~ (cis_3_4_1_2_pf.stdout | trim | upper),
-              ('COMPLIANT: exactly one firewall utility is enabled'
-               if ([cis_3_4_1_2_ipfw.stdout | trim | upper == 'YES',
-                    cis_3_4_1_2_ipfilter.stdout | trim | upper == 'YES',
-                    cis_3_4_1_2_pf.stdout | trim | upper == 'YES'] | select | list | length) == 1
-               else 'NON-COMPLIANT: zero or multiple firewall utilities are enabled — ensure exactly one is in use')] | join('\n') }}
+        msg: "{{ ['3.4.1.2 Firewall utility audit:', ''] +
+              ['  firewall_enable (ipfw): ' ~ (cis_3_4_1_2_ipfw.stdout | trim | upper),
+               '  ipfilter_enable:        ' ~ (cis_3_4_1_2_ipfilter.stdout | trim | upper),
+               '  pf_enable:              ' ~ (cis_3_4_1_2_pf.stdout | trim | upper),
+               '',
+               ('COMPLIANT: exactly one firewall utility is enabled'
+                if ([cis_3_4_1_2_ipfw.stdout | trim | upper == 'YES',
+                     cis_3_4_1_2_ipfilter.stdout | trim | upper == 'YES',
+                     cis_3_4_1_2_pf.stdout | trim | upper == 'YES'] | select | list | length) == 1
+                else 'NON-COMPLIANT: zero or multiple firewall utilities are enabled — ensure exactly one is in use')] }}"

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -115,7 +115,7 @@
                else '  gateway_enable: COMPLIANT — not YES'),
               ('  ipv6_gateway_enable: NON-COMPLIANT — set to YES'
                if cis_3_3_1_ipv6_gw.stdout | trim | upper == 'YES'
-               else '  ipv6_gateway_enable: COMPLIANT — not YES')] | join('\n') }}
+               else '  ipv6_gateway_enable: COMPLIANT — not YES')] }}
 
     - name: "3.3.1 | REMEDIATE | Disable IPv4 forwarding in sysctl.conf"
       ansible.builtin.lineinfile:
@@ -206,7 +206,7 @@
                else '  net.inet.ip.redirect: COMPLIANT — set to 0'),
               ('  net.inet6.ip6.redirect: NON-COMPLIANT — set to 1 (redirects enabled)'
                if cis_3_3_2_ipv6_redirect.stdout | trim == '1'
-               else '  net.inet6.ip6.redirect: COMPLIANT — set to 0')] | join('\n') }}
+               else '  net.inet6.ip6.redirect: COMPLIANT — set to 0')] }}
 
     - name: "3.3.2 | REMEDIATE | Disable IPv4 redirect sending in sysctl.conf"
       ansible.builtin.lineinfile:
@@ -277,7 +277,7 @@
                else '  net.inet.icmp.bmcastecho: COMPLIANT — set to 0'),
               ('  net.inet.icmp.tstamprepl: NON-COMPLIANT — set to 1 (timestamp replies enabled)'
                if cis_3_3_3_tstamp.stdout | trim == '1'
-               else '  net.inet.icmp.tstamprepl: COMPLIANT — set to 0')] | join('\n') }}
+               else '  net.inet.icmp.tstamprepl: COMPLIANT — set to 0')] }}
 
     - name: "3.3.3 | REMEDIATE | Disable bmcastecho in sysctl.conf"
       ansible.builtin.lineinfile:
@@ -348,7 +348,7 @@
                else '  net.inet.icmp.drop_redirect: COMPLIANT — set to 1'),
               ('  net.inet6.icmp6.rediraccept: NON-COMPLIANT — set to 1 (IPv6 redirects accepted)'
                if cis_3_3_4_redir6.stdout | trim == '1'
-               else '  net.inet6.icmp6.rediraccept: COMPLIANT — set to 0')] | join('\n') }}
+               else '  net.inet6.icmp6.rediraccept: COMPLIANT — set to 0')] }}
 
     - name: "3.3.4 | REMEDIATE | Set drop_redirect=1 in sysctl.conf"
       ansible.builtin.lineinfile:

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -44,6 +44,18 @@
       failed_when: false
       check_mode: false
 
+    - name: "3.2.1 | AUDIT | Check sctp boot-load setting in loader.conf"
+      ansible.builtin.command:
+        argv:
+          - grep
+          - -E
+          - '^[[:space:]]*sctp_load="NO"[[:space:]]*$'
+          - /boot/loader.conf
+      register: cis_3_2_1_sctp_loader_no
+      changed_when: cis_3_2_1_sctp_loader_no.rc != 0
+      failed_when: false
+      check_mode: false
+
     - name: "3.2.1 | AUDIT | Report sctp module state"
       ansible.builtin.debug:
         msg: >-
@@ -62,7 +74,7 @@
         mode: '0600'
       when:
         - freebsd_cis_remediate | bool
-        - cis_3_2_1_sctp.rc == 0
+        - cis_3_2_1_sctp.rc == 0 or cis_3_2_1_sctp_loader_no.rc != 0
 
 # =============================================================
 # 3.3 Configure Network Kernel Parameters

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -40,7 +40,7 @@
     - name: "3.2.1 | AUDIT | Check whether sctp module is loaded"
       ansible.builtin.command: kldstat -q -m sctp
       register: cis_3_2_1_sctp
-      changed_when: false
+      changed_when: cis_3_2_1_sctp.rc == 0
       failed_when: false
       check_mode: false
 
@@ -51,15 +51,15 @@
              if cis_3_2_1_sctp.rc == 0
              else 'COMPLIANT: sctp kernel module is NOT loaded' }}
 
-    - name: "3.2.1 | REMEDIATE | Blacklist sctp module in loader.conf"
+    - name: "3.2.1 | REMEDIATE | Disable sctp module in loader.conf"
       ansible.builtin.lineinfile:
         path: /boot/loader.conf
-        regexp: '^module_blacklist='
-        line: 'module_blacklist="sctp"'
+        regexp: '^sctp_load='
+        line: 'sctp_load="NO"'
         create: true
         owner: root
         group: wheel
-        mode: '0644'
+        mode: '0600'
       when:
         - freebsd_cis_remediate | bool
         - cis_3_2_1_sctp.rc == 0
@@ -75,28 +75,28 @@
     - name: "3.3.1 | AUDIT | Check net.inet.ip.forwarding"
       ansible.builtin.command: sysctl -nq net.inet.ip.forwarding
       register: cis_3_3_1_ipv4_fwd
-      changed_when: false
+      changed_when: cis_3_3_1_ipv4_fwd.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
     - name: "3.3.1 | AUDIT | Check net.inet6.ip6.forwarding"
       ansible.builtin.command: sysctl -nq net.inet6.ip6.forwarding
       register: cis_3_3_1_ipv6_fwd
-      changed_when: false
+      changed_when: cis_3_3_1_ipv6_fwd.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
     - name: "3.3.1 | AUDIT | Check gateway_enable rc.conf setting"
       ansible.builtin.command: sysrc -q -n gateway_enable
       register: cis_3_3_1_gw
-      changed_when: false
+      changed_when: cis_3_3_1_gw.stdout | trim | upper == 'YES'
       failed_when: false
       check_mode: false
 
     - name: "3.3.1 | AUDIT | Check ipv6_gateway_enable rc.conf setting"
       ansible.builtin.command: sysrc -q -n ipv6_gateway_enable
       register: cis_3_3_1_ipv6_gw
-      changed_when: false
+      changed_when: cis_3_3_1_ipv6_gw.stdout | trim | upper == 'YES'
       failed_when: false
       check_mode: false
 
@@ -186,14 +186,14 @@
     - name: "3.3.2 | AUDIT | Check net.inet.ip.redirect"
       ansible.builtin.command: sysctl -nq net.inet.ip.redirect
       register: cis_3_3_2_ipv4_redirect
-      changed_when: false
+      changed_when: cis_3_3_2_ipv4_redirect.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
     - name: "3.3.2 | AUDIT | Check net.inet6.ip6.redirect"
       ansible.builtin.command: sysctl -nq net.inet6.ip6.redirect
       register: cis_3_3_2_ipv6_redirect
-      changed_when: false
+      changed_when: cis_3_3_2_ipv6_redirect.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
@@ -257,14 +257,14 @@
     - name: "3.3.3 | AUDIT | Check net.inet.icmp.bmcastecho"
       ansible.builtin.command: sysctl -nq net.inet.icmp.bmcastecho
       register: cis_3_3_3_bmcast
-      changed_when: false
+      changed_when: cis_3_3_3_bmcast.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
     - name: "3.3.3 | AUDIT | Check net.inet.icmp.tstamprepl"
       ansible.builtin.command: sysctl -nq net.inet.icmp.tstamprepl
       register: cis_3_3_3_tstamp
-      changed_when: false
+      changed_when: cis_3_3_3_tstamp.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
@@ -328,14 +328,14 @@
     - name: "3.3.4 | AUDIT | Check net.inet.icmp.drop_redirect"
       ansible.builtin.command: sysctl -nq net.inet.icmp.drop_redirect
       register: cis_3_3_4_drop_redirect
-      changed_when: false
+      changed_when: cis_3_3_4_drop_redirect.stdout | trim == '0'
       failed_when: false
       check_mode: false
 
     - name: "3.3.4 | AUDIT | Check net.inet6.icmp6.rediraccept"
       ansible.builtin.command: sysctl -nq net.inet6.icmp6.rediraccept
       register: cis_3_3_4_redir6
-      changed_when: false
+      changed_when: cis_3_3_4_redir6.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
@@ -399,7 +399,7 @@
     - name: "3.3.5 | AUDIT | Check net.inet.ip.accept_sourceroute"
       ansible.builtin.command: sysctl -nq net.inet.ip.accept_sourceroute
       register: cis_3_3_5_srcroute
-      changed_when: false
+      changed_when: cis_3_3_5_srcroute.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
@@ -439,7 +439,7 @@
     - name: "3.3.6 | AUDIT | Check net.inet.tcp.syncookies"
       ansible.builtin.command: sysctl -nq net.inet.tcp.syncookies
       register: cis_3_3_6_syncookies
-      changed_when: false
+      changed_when: cis_3_3_6_syncookies.stdout | trim == '0'
       failed_when: false
       check_mode: false
 
@@ -479,7 +479,7 @@
     - name: "3.3.7 | AUDIT | Check net.inet6.ip6.accept_rtadv"
       ansible.builtin.command: sysctl -nq net.inet6.ip6.accept_rtadv
       register: cis_3_3_7_rtadv
-      changed_when: false
+      changed_when: cis_3_3_7_rtadv.stdout | trim == '1'
       failed_when: false
       check_mode: false
 
@@ -522,7 +522,7 @@
     - name: "3.4.1.1 | AUDIT | Check firewall_enable rc.conf setting"
       ansible.builtin.command: sysrc -q -n firewall_enable
       register: cis_3_4_1_1_ipfw
-      changed_when: false
+      changed_when: cis_3_4_1_1_ipfw.stdout | trim | upper != 'YES'
       failed_when: false
       check_mode: false
 


### PR DESCRIPTION
## Summary

Two commits:
1. **fix**: Update `tasks/section_2.yml` audit messages to use COMPLIANT/NON-COMPLIANT terminology (carried forward from PR #3 work)
2. **feat**: Implement all controls from **Section 3 — Network** in `tasks/section_3.yml`

## Why

Section 3 was a stub (`[]`). Section 2 terminology fix was missed in PR #3.

## Controls implemented

| Control | Level | Subject |
|---|---|---|
| 3.1.1 | L1 | Ensure IPv6 status is identified (report-only) |
| 3.2.1 | L2 | Ensure sctp kernel module is not available |
| 3.3.1 | L1 | Ensure IP forwarding is disabled (IPv4 + IPv6; gateway/ipv6_gateway services) |
| 3.3.2 | L1 | Ensure packet redirect sending is disabled |
| 3.3.3 | L1 | Ensure broadcast and multicast ICMP requests are ignored |
| 3.3.4 | L1 | Ensure ICMP redirects are not accepted |
| 3.3.5 | L1 | Ensure source routed packets are not accepted |
| 3.3.6 | L1 | Ensure TCP SYN cookies is enabled |
| 3.3.7 | L1 | Ensure IPv6 router advertisements are not accepted |
| 3.4.1.1 | L1 | Ensure ipfw is enabled and configured |
| 3.4.1.2 | L1 | Ensure a single firewall utility is in use (audit-only report) |

## Design notes

- **sysctl audits**: `sysctl -nq <key>` + Jinja string compare — no shell pipes, lint-clean.
- **sysctl remediation**: dual-step — `lineinfile` for persistence in `/etc/sysctl.conf`, then `command: sysctl` for immediate runtime effect.
- **lineinfile permissions**: all writes to `/etc/sysctl.conf` and `/boot/loader.conf` explicitly set `owner: root`, `group: wheel`, `mode: '0644'`.
- **3.1.1**: Report-only — benchmark says "identify" and configure per site policy; no automated remediation is appropriate.
- **3.2.1**: Gated on `freebsd_cis_level >= 2` per benchmark (Level 2 control).
- **3.3.1**: Handles both IPv4/IPv6 sysctl and the `gateway`/`ipv6_gateway` rc services.
- **3.4.1.1**: Remediation sets `firewall_type=workstation` (sane default per benchmark); operator must customize services via `firewall_myservices`.
- **3.4.1.2**: Audit-only — reports enabled firewall counts; no automated remediation (disabling the wrong firewall mid-session is operationally dangerous).

## Lint gate

```
ansible-lint tasks/section_3.yml
Passed: 0 failure(s), 0 warning(s) — profile: production
```

## Validation performed

Test run against `host.example.com` (`freebsd_cis_remediate: false`, Level 1):

```
PLAY RECAP *******************************************
host.example.com : ok=30  changed=0  unreachable=0  failed=0  skipped=29  rescued=0  ignored=0
```

0 failures, 0 unreachable. All audit tasks ran; Level 2 and excepted controls skipped as expected.

Lint passes at production profile.

## Risks and follow-ups

- 3.3.1 gateway/ipv6_gateway remediation uses `ansible.builtin.service` with `state: stopped` — on a system that is intentionally a router this would break routing. The `active_exceptions` mechanism is the correct operator escape hatch.
- 3.4.1.1 remediation does not restart ipfw (a reboot or manual `service ipfw start` is needed to load kernel modules for the first time). This is consistent with the benchmark guidance.
