### PR TITLE
feat: implement CIS Section 4a controls (4.1.1.1–4.2.21)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,20 +38,33 @@ freebsd_cis_warning_banner: >-
 # Section 4 — Access, Authentication and Authorization
 # -------------------------------------------------------------------
 
+# 4.2.x — SSH implementation selector.
+# 'base'  — FreeBSD base system sshd  (default)
+# 'ports' — OpenSSH installed from ports/packages
+# Setting this automatically derives the four variables below.
+# Override any of them individually if your layout differs from standard paths.
+freebsd_cis_sshd_source: base
+
 # 4.2.x — Path to sshd_config.
-# FreeBSD base sshd uses /etc/ssh/sshd_config.
-# OpenSSH installed from ports/packages uses /usr/local/etc/ssh/sshd_config.
-freebsd_cis_sshd_config: /etc/ssh/sshd_config
+freebsd_cis_sshd_config: >-
+  {{ '/usr/local/etc/ssh/sshd_config' if freebsd_cis_sshd_source == 'ports'
+     else '/etc/ssh/sshd_config' }}
 
 # 4.2.x — Path to the sshd binary used for configuration test/query (-T flag).
-# FreeBSD base: /usr/sbin/sshd
-# Ports/packages OpenSSH: /usr/local/sbin/sshd
-freebsd_cis_sshd_bin: /usr/sbin/sshd
+freebsd_cis_sshd_bin: >-
+  {{ '/usr/local/sbin/sshd' if freebsd_cis_sshd_source == 'ports'
+     else '/usr/sbin/sshd' }}
 
 # 4.2.x — Path to the ssh binary (used for version checks if needed).
-# FreeBSD base: /usr/bin/ssh
-# Ports/packages OpenSSH: /usr/local/bin/ssh
-freebsd_cis_ssh_bin: /usr/bin/ssh
+freebsd_cis_ssh_bin: >-
+  {{ '/usr/local/bin/ssh' if freebsd_cis_sshd_source == 'ports'
+     else '/usr/bin/ssh' }}
+
+# 4.2.x — rc.d service name for sshd reload.
+# FreeBSD base: sshd  |  Ports OpenSSH: openssh
+freebsd_cis_sshd_service: >-
+  {{ 'openssh' if freebsd_cis_sshd_source == 'ports'
+     else 'sshd' }}
 
 # 4.2.4 — sshd access restriction (AllowUsers / AllowGroups / DenyUsers / DenyGroups).
 # Set at least one to a non-empty string to enable automated remediation.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,62 @@ freebsd_cis_bootloader_password: ""
 # /etc/issue, and /etc/issue.net. Customize per site policy and legal review.
 freebsd_cis_warning_banner: >-
   Authorized users only. All activity may be monitored and reported.
+
+# -------------------------------------------------------------------
+# Section 4 — Access, Authentication and Authorization
+# -------------------------------------------------------------------
+
+# 4.2.x — Path to sshd_config.
+# FreeBSD base sshd uses /etc/ssh/sshd_config.
+# OpenSSH installed from ports/packages uses /usr/local/etc/ssh/sshd_config.
+freebsd_cis_sshd_config: /etc/ssh/sshd_config
+
+# 4.2.x — Path to the sshd binary used for configuration test/query (-T flag).
+# FreeBSD base: /usr/sbin/sshd
+# Ports/packages OpenSSH: /usr/local/sbin/sshd
+freebsd_cis_sshd_bin: /usr/sbin/sshd
+
+# 4.2.x — Path to the ssh binary (used for version checks if needed).
+# FreeBSD base: /usr/bin/ssh
+# Ports/packages OpenSSH: /usr/local/bin/ssh
+freebsd_cis_ssh_bin: /usr/bin/ssh
+
+# 4.2.4 — sshd access restriction (AllowUsers / AllowGroups / DenyUsers / DenyGroups).
+# Set at least one to a non-empty string to enable automated remediation.
+# Leave all empty to skip the remediation task (the audit will still run).
+freebsd_cis_sshd_allow_users: ""
+freebsd_cis_sshd_allow_groups: ""
+freebsd_cis_sshd_deny_users: ""
+freebsd_cis_sshd_deny_groups: ""
+
+# 4.2.5 — Banner file path sent to remote users before authentication.
+freebsd_cis_sshd_banner: /etc/issue.net
+
+# 4.2.6 — Comma-separated list of weak ciphers to remove (minus-prefix syntax).
+freebsd_cis_sshd_weak_ciphers: "3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se"
+
+# 4.2.7 — Idle connection timeout. ClientAliveInterval must be > 0; CountMax must be > 0.
+freebsd_cis_sshd_client_alive_interval: 15
+freebsd_cis_sshd_client_alive_count_max: 3
+
+# 4.2.11 — Comma-separated list of weak key-exchange algorithms to remove.
+freebsd_cis_sshd_weak_kex: "diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1"
+
+# 4.2.12 — Maximum seconds allowed for successful authentication (1-60 or 1m).
+freebsd_cis_sshd_login_grace_time: 60
+
+# 4.2.13 — sshd log verbosity (VERBOSE or INFO).
+freebsd_cis_sshd_log_level: "VERBOSE"
+
+# 4.2.14 — Comma-separated list of weak MAC algorithms to remove.
+freebsd_cis_sshd_weak_macs: >-
+  hmac-md5,hmac-md5-96,hmac-ripemd160,hmac-sha1-96,umac-64@openssh.com,hmac-md5-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,umac-64-etm@openssh.com
+
+# 4.2.15 — Maximum authentication attempts per connection (benchmark recommends 4).
+freebsd_cis_sshd_max_auth_tries: 4
+
+# 4.2.16 — Maximum open sessions per connection (benchmark requires <= 10).
+freebsd_cis_sshd_max_sessions: 10
+
+# 4.2.17 — MaxStartups throttle: start:rate:full (benchmark recommends 10:30:60).
+freebsd_cis_sshd_max_startups: "10:30:60"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,8 @@
+---
+# FreeBSD 14 CIS Benchmark v1.0.1 — Role Handlers
+
+- name: Reload sshd
+  ansible.builtin.service:
+    name: sshd
+    state: reloaded
+  failed_when: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,7 +2,18 @@
 # FreeBSD 14 CIS Benchmark v1.0.1 — Role Handlers
 
 - name: Reload sshd
-  ansible.builtin.service:
-    name: "{{ freebsd_cis_sshd_service }}"
-    state: reloaded
-  failed_when: false
+  block:
+    - name: Reload sshd | Validate sshd configuration
+      ansible.builtin.command:
+        argv:
+          - "{{ freebsd_cis_sshd_bin }}"
+          - -t
+          - -f
+          - "{{ freebsd_cis_sshd_config }}"
+      changed_when: false
+
+    - name: Reload sshd | Reload service
+      ansible.builtin.service:
+        name: "{{ freebsd_cis_sshd_service }}"
+        state: reloaded
+      failed_when: false  # acceptable: sshd may not be running

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,6 @@
 
 - name: Reload sshd
   ansible.builtin.service:
-    name: sshd
+    name: "{{ freebsd_cis_sshd_service }}"
     state: reloaded
   failed_when: false

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -259,9 +259,9 @@
       - -C
       - "user=root"
       - -C
-      - "host={{ ansible_hostname }}"
+      - "host={{ ansible_facts['hostname'] }}"
       - -C
-      - "addr={{ ansible_default_ipv4.address | default('127.0.0.1') }}"
+      - "addr={{ ansible_facts['default_ipv4']['address'] | default('127.0.0.1') }}"
   register: cis_4_2_sshd_config_dump
   changed_when: false
   failed_when: false

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -46,7 +46,10 @@
         mode: '0600'
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_1_1_1_crontab is changed
+        - cis_4_1_1_1_crontab.stat.exists
+        - cis_4_1_1_1_crontab.stat.pw_name != 'root' or
+          cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
+          (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -86,7 +89,10 @@
         mode: '0700'
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_1_1_2_crond is changed
+        - cis_4_1_1_2_crond.stat.exists
+        - cis_4_1_1_2_crond.stat.pw_name != 'root' or
+          cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
+          (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -267,6 +273,15 @@
   failed_when: false
   check_mode: false
 
+- name: "4.2 | GATHER | Report sshd -T query status"
+  ansible.builtin.debug:
+    msg: >-
+      {{ 'NON-COMPLIANT: sshd -T query failed (rc=' ~ cis_4_2_sshd_config_dump.rc ~
+         ') — effective configuration unavailable; dependent controls 4.2.4–4.2.21 may report incorrect results'
+         if cis_4_2_sshd_config_dump.rc != 0
+         else 'sshd -T: effective configuration query succeeded' }}
+  changed_when: cis_4_2_sshd_config_dump.rc != 0
+
 # ---
 
 - name: "4.2.1 | Ensure permissions on /etc/ssh/sshd_config are configured"
@@ -305,7 +320,10 @@
         mode: '0600'
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_2_1_sshdcfg is changed
+        - cis_4_2_1_sshdcfg.stat.exists
+        - cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
+          cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
+          (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -346,6 +364,18 @@
       loop: "{{ cis_4_2_2_privkey_stats.results }}"
       loop_control:
         label: "{{ item.stat.path }}"
+
+    - name: "4.2.2 | AUDIT | Summarize private key compliance"
+      ansible.builtin.set_fact:
+        cis_4_2_2_non_compliant: >-
+          {{ (cis_4_2_2_privkey_stats.results
+              | selectattr('stat.pw_name', 'ne', 'root') | list | length > 0)
+             or (cis_4_2_2_privkey_stats.results
+              | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
+             or (cis_4_2_2_privkey_stats.results
+              | rejectattr('stat.mode', 'match', '^0[0-7]00$') | list | length > 0) }}
+      changed_when: cis_4_2_2_non_compliant | bool
+      check_mode: false
 
     - name: "4.2.2 | REMEDIATE | Fix SSH private host key file permissions"
       ansible.builtin.file:
@@ -402,6 +432,18 @@
       loop: "{{ cis_4_2_3_pubkey_stats.results }}"
       loop_control:
         label: "{{ item.stat.path }}"
+
+    - name: "4.2.3 | AUDIT | Summarize public key compliance"
+      ansible.builtin.set_fact:
+        cis_4_2_3_non_compliant: >-
+          {{ (cis_4_2_3_pubkey_stats.results
+              | selectattr('stat.pw_name', 'ne', 'root') | list | length > 0)
+             or (cis_4_2_3_pubkey_stats.results
+              | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
+             or (cis_4_2_3_pubkey_stats.results
+              | rejectattr('stat.mode', 'match', '^0[0-7][04][04]$') | list | length > 0) }}
+      changed_when: cis_4_2_3_non_compliant | bool
+      check_mode: false
 
     - name: "4.2.3 | REMEDIATE | Fix SSH public host key file permissions"
       ansible.builtin.file:
@@ -541,18 +583,19 @@
 
     - name: "4.2.6 | AUDIT | Extract effective cipher list"
       ansible.builtin.set_fact:
-        cis_4_2_6_ciphers: >-
-          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+        cis_4_2_6_cipher_list: >-
+          {{ (cis_4_2_sshd_config_dump.stdout_lines | default([])
              | select('match', '^ciphers\s')
              | list | first | default('ciphers')
-             | regex_replace('^ciphers\s+', '') | trim }}
+             | regex_replace('^ciphers\s+', '') | trim).split(',')
+             | map('trim') | list }}
       check_mode: false
 
     - name: "4.2.6 | AUDIT | Check for weak ciphers"
       ansible.builtin.set_fact:
         cis_4_2_6_weak_found: >-
           {{ freebsd_cis_sshd_weak_ciphers.split(',')
-             | select('in', cis_4_2_6_ciphers) | list }}
+             | map('trim') | select('in', cis_4_2_6_cipher_list) | list }}
       changed_when: cis_4_2_6_weak_found | length > 0
       check_mode: false
 
@@ -755,18 +798,19 @@
 
     - name: "4.2.11 | AUDIT | Extract effective KexAlgorithms"
       ansible.builtin.set_fact:
-        cis_4_2_11_kex: >-
-          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+        cis_4_2_11_kex_list: >-
+          {{ (cis_4_2_sshd_config_dump.stdout_lines | default([])
              | select('match', '^kexalgorithms\s')
              | list | first | default('kexalgorithms')
-             | regex_replace('^kexalgorithms\s+', '') | trim }}
+             | regex_replace('^kexalgorithms\s+', '') | trim).split(',')
+             | map('trim') | list }}
       check_mode: false
 
     - name: "4.2.11 | AUDIT | Check for weak KexAlgorithms"
       ansible.builtin.set_fact:
         cis_4_2_11_weak_found: >-
           {{ freebsd_cis_sshd_weak_kex.split(',')
-             | select('in', cis_4_2_11_kex) | list }}
+             | map('trim') | select('in', cis_4_2_11_kex_list) | list }}
       changed_when: cis_4_2_11_weak_found | length > 0
       check_mode: false
 
@@ -874,18 +918,19 @@
 
     - name: "4.2.14 | AUDIT | Extract effective MACs list"
       ansible.builtin.set_fact:
-        cis_4_2_14_macs: >-
-          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+        cis_4_2_14_macs_list: >-
+          {{ (cis_4_2_sshd_config_dump.stdout_lines | default([])
              | select('match', '^macs\s')
              | list | first | default('macs')
-             | regex_replace('^macs\s+', '') | trim }}
+             | regex_replace('^macs\s+', '') | trim).split(',')
+             | map('trim') | list }}
       check_mode: false
 
     - name: "4.2.14 | AUDIT | Check for weak MACs"
       ansible.builtin.set_fact:
         cis_4_2_14_weak_found: >-
           {{ freebsd_cis_sshd_weak_macs.split(',')
-             | select('in', cis_4_2_14_macs) | list }}
+             | map('trim') | select('in', cis_4_2_14_macs_list) | list }}
       changed_when: cis_4_2_14_weak_found | length > 0
       check_mode: false
 

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -69,7 +69,7 @@
         cis_4_1_1_2_crond.stat.pw_name != 'root' or
         cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
         (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
-        ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) % 2 == 0
+        ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) != 7
       failed_when: false
       check_mode: false
 
@@ -96,7 +96,7 @@
         - cis_4_1_1_2_crond.stat.pw_name != 'root' or
           cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
           (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
-          ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) % 2 == 0
+          ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) != 7
 
 # ---
 
@@ -653,6 +653,7 @@
              | list | first | default('ciphers')
              | regex_replace('^ciphers\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.6 | AUDIT | Check for weak ciphers"
@@ -868,6 +869,7 @@
              | list | first | default('kexalgorithms')
              | regex_replace('^kexalgorithms\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.11 | AUDIT | Check for weak KexAlgorithms"
@@ -988,6 +990,7 @@
              | list | first | default('macs')
              | regex_replace('^macs\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.14 | AUDIT | Check for weak MACs"
@@ -1106,6 +1109,7 @@
              | select('match', '^maxstartups\s')
              | list | first | default('maxstartups 10:30:100')
              | regex_replace('^maxstartups\s+', '') | trim }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.17 | AUDIT | Parse MaxStartups components"

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1115,8 +1115,10 @@
     - name: "4.2.17 | AUDIT | Parse MaxStartups components"
       ansible.builtin.set_fact:
         cis_4_2_17_start: "{{ cis_4_2_17_val.split(':')[0] | int }}"
-        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 100 }}"
-        cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else 100 }}"
+        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 0 }}"
+        cis_4_2_17_full: >-
+          {{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2
+             else (cis_4_2_17_val | int if ':' not in cis_4_2_17_val else 100) }}
       changed_when: >-
         (cis_4_2_17_start | int) > 10 or
         (cis_4_2_17_rate | int) > 30 or

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -267,7 +267,7 @@
       - -C
       - "host={{ ansible_facts['hostname'] }}"
       - -C
-      - "addr={{ ansible_facts['default_ipv4']['address'] | default('127.0.0.1') }}"
+      - "addr={{ ((ansible_facts['default_ipv4'] | default({})).address) | default('127.0.0.1') }}"
   register: cis_4_2_sshd_config_dump
   changed_when: false
   failed_when: false
@@ -297,7 +297,8 @@
         not cis_4_2_1_sshdcfg.stat.exists or
         cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
         cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
-        (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
+        (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0 or
+        ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
       failed_when: false
       check_mode: false
 
@@ -323,7 +324,8 @@
         - cis_4_2_1_sshdcfg.stat.exists
         - cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
           cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
-          (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
+          (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0 or
+          ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
 
 # ---
 
@@ -359,7 +361,8 @@
              ' — expected root:wheel mode 0600'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
-                 (item.stat.mode | int(base=8)) % 64 != 0)
+                 (item.stat.mode | int(base=8)) % 64 != 0 or
+                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6])
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
       loop: "{{ cis_4_2_2_privkey_stats.results }}"
       loop_control:
@@ -373,7 +376,7 @@
              or (cis_4_2_2_privkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_2_privkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[0-7]00$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[46]00$') | list | length > 0) }}
       changed_when: cis_4_2_2_non_compliant | bool
       check_mode: false
 
@@ -390,7 +393,8 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
-          (item.stat.mode | int(base=8)) % 64 != 0
+          (item.stat.mode | int(base=8)) % 64 != 0 or
+          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
 
 # ---
 
@@ -426,6 +430,7 @@
              ' — expected root:wheel mode 0644'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
+                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
                  (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
                  ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4])
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
@@ -441,7 +446,7 @@
              or (cis_4_2_3_pubkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_3_pubkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[0-7][04][04]$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[46][04][04]$') | list | length > 0) }}
       changed_when: cis_4_2_3_non_compliant | bool
       check_mode: false
 
@@ -458,6 +463,7 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
+          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
           ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4]
 

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -398,6 +398,7 @@
         patterns: "ssh_host_*_key"
         file_type: file
       register: cis_4_2_2_privkeys
+      failed_when: false
       check_mode: false
 
     - name: "4.2.2 | AUDIT | Check private key permissions"
@@ -467,6 +468,7 @@
         patterns: "ssh_host_*_key.pub"
         file_type: file
       register: cis_4_2_3_pubkeys
+      failed_when: false
       check_mode: false
 
     - name: "4.2.3 | AUDIT | Check public key permissions"
@@ -553,6 +555,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*AllowUsers\s'
         line: "AllowUsers {{ freebsd_cis_sshd_allow_users }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -566,6 +570,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*AllowGroups\s'
         line: "AllowGroups {{ freebsd_cis_sshd_allow_groups }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -579,6 +585,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DenyUsers\s'
         line: "DenyUsers {{ freebsd_cis_sshd_deny_users }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -592,6 +600,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DenyGroups\s'
         line: "DenyGroups {{ freebsd_cis_sshd_deny_groups }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -630,6 +640,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*Banner\s'
         line: "Banner {{ freebsd_cis_sshd_banner }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -676,6 +688,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*Ciphers\s'
         line: "Ciphers -{{ freebsd_cis_sshd_weak_ciphers }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -722,6 +736,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*ClientAliveInterval\s'
         line: "ClientAliveInterval {{ freebsd_cis_sshd_client_alive_interval }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -735,6 +751,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*ClientAliveCountMax\s'
         line: "ClientAliveCountMax {{ freebsd_cis_sshd_client_alive_count_max }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -772,6 +790,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DisableForwarding\s'
         line: 'DisableForwarding yes'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -809,6 +829,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*HostbasedAuthentication\s'
         line: 'HostbasedAuthentication no'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -846,6 +868,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*IgnoreRhosts\s'
         line: 'IgnoreRhosts yes'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -892,6 +916,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*KexAlgorithms\s'
         line: "KexAlgorithms -{{ freebsd_cis_sshd_weak_kex }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -930,6 +956,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*LoginGraceTime\s'
         line: "LoginGraceTime {{ freebsd_cis_sshd_login_grace_time }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -967,6 +995,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*LogLevel\s'
         line: "LogLevel {{ freebsd_cis_sshd_log_level }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1013,6 +1043,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MACs\s'
         line: "MACs -{{ freebsd_cis_sshd_weak_macs }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1050,6 +1082,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxAuthTries\s'
         line: "MaxAuthTries {{ freebsd_cis_sshd_max_auth_tries }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1087,6 +1121,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxSessions\s'
         line: "MaxSessions {{ freebsd_cis_sshd_max_sessions }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1140,6 +1176,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxStartups\s'
         line: "MaxStartups {{ freebsd_cis_sshd_max_startups }}"
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1179,6 +1217,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitEmptyPasswords\s'
         line: 'PermitEmptyPasswords no'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1216,6 +1256,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitRootLogin\s'
         line: 'PermitRootLogin no'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1253,6 +1295,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitUserEnvironment\s'
         line: 'PermitUserEnvironment no'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1290,6 +1334,8 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*UsePAM\s'
         line: 'UsePAM yes'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -120,13 +120,15 @@
              cis_4_1_1_3_allow.stat.pw_name == 'root' and
              cis_4_1_1_3_allow.stat.gr_name == 'wheel' and
              (cis_4_1_1_3_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
         cis_4_1_1_3_deny_ok: >-
           {{ not cis_4_1_1_3_deny.stat.exists or
              (cis_4_1_1_3_deny.stat.pw_name == 'root' and
               cis_4_1_1_3_deny.stat.gr_name == 'wheel' and
               (cis_4_1_1_3_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
       changed_when: not (cis_4_1_1_3_allow_ok | bool) or not (cis_4_1_1_3_deny_ok | bool)
       check_mode: false
 
@@ -199,13 +201,15 @@
              cis_4_1_2_1_allow.stat.pw_name in ['root', 'daemon'] and
              cis_4_1_2_1_allow.stat.gr_name == 'wheel' and
              (cis_4_1_2_1_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
         cis_4_1_2_1_deny_ok: >-
           {{ not cis_4_1_2_1_deny.stat.exists or
              (cis_4_1_2_1_deny.stat.pw_name in ['root', 'daemon'] and
               cis_4_1_2_1_deny.stat.gr_name == 'wheel' and
               (cis_4_1_2_1_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
       changed_when: not (cis_4_1_2_1_allow_ok | bool) or not (cis_4_1_2_1_deny_ok | bool)
       check_mode: false
 
@@ -272,6 +276,26 @@
   changed_when: false
   failed_when: false
   check_mode: false
+  tags:
+    - section_4
+    - rule_4.2.4
+    - rule_4.2.5
+    - rule_4.2.6
+    - rule_4.2.7
+    - rule_4.2.8
+    - rule_4.2.9
+    - rule_4.2.10
+    - rule_4.2.11
+    - rule_4.2.12
+    - rule_4.2.13
+    - rule_4.2.14
+    - rule_4.2.15
+    - rule_4.2.16
+    - rule_4.2.17
+    - rule_4.2.18
+    - rule_4.2.19
+    - rule_4.2.20
+    - rule_4.2.21
 
 - name: "4.2 | GATHER | Report sshd -T query status"
   ansible.builtin.debug:
@@ -281,6 +305,26 @@
          if cis_4_2_sshd_config_dump.rc != 0
          else 'sshd -T: effective configuration query succeeded' }}
   changed_when: cis_4_2_sshd_config_dump.rc != 0
+  tags:
+    - section_4
+    - rule_4.2.4
+    - rule_4.2.5
+    - rule_4.2.6
+    - rule_4.2.7
+    - rule_4.2.8
+    - rule_4.2.9
+    - rule_4.2.10
+    - rule_4.2.11
+    - rule_4.2.12
+    - rule_4.2.13
+    - rule_4.2.14
+    - rule_4.2.15
+    - rule_4.2.16
+    - rule_4.2.17
+    - rule_4.2.18
+    - rule_4.2.19
+    - rule_4.2.20
+    - rule_4.2.21
 
 # ---
 
@@ -358,7 +402,7 @@
              (item.stat.pw_name | default('?')) ~ ' group=' ~
              (item.stat.gr_name | default('?')) ~ ' mode=' ~
              (item.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0600'
+             ' — expected root:wheel mode 0600 or more restrictive (0400 permitted)'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
                  (item.stat.mode | int(base=8)) % 64 != 0 or
@@ -427,7 +471,7 @@
              (item.stat.pw_name | default('?')) ~ ' group=' ~
              (item.stat.gr_name | default('?')) ~ ' mode=' ~
              (item.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0644'
+             ' — expected root:wheel mode 0644 or more restrictive'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
                  ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -23,7 +23,8 @@
         not cis_4_1_1_1_crontab.stat.exists or
         cis_4_1_1_1_crontab.stat.pw_name != 'root' or
         cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
-        (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
+        (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0 or
+        ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
       failed_when: false
       check_mode: false
 
@@ -49,7 +50,8 @@
         - cis_4_1_1_1_crontab.stat.exists
         - cis_4_1_1_1_crontab.stat.pw_name != 'root' or
           cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
-          (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
+          (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0 or
+          ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
 
 # ---
 
@@ -266,6 +268,8 @@
     argv:
       - "{{ freebsd_cis_sshd_bin }}"
       - -T
+      - -f
+      - "{{ freebsd_cis_sshd_config }}"
       - -C
       - "user=root"
       - -C

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1,5 +1,1184 @@
 ---
 # FreeBSD 14 CIS Benchmark v1.0.1
-# Section 4 — Access, Authentication and Authorization
-# Controls: 4.1.1.1 – 4.5.3.2
-[]
+# Section 4 — Access, Authentication and Authorization (Part A)
+# Controls: 4.1.1.1 – 4.2.21
+# lint-clean: production profile
+
+# =============================================================
+# 4.1 Configure job schedulers
+# =============================================================
+
+# ---
+
+- name: "4.1.1.1 | Ensure permissions on /etc/crontab are configured"
+  when: "'4.1.1.1' not in active_exceptions"
+  tags: [rule_4.1.1.1, level1, section_4, automated]
+  block:
+
+    - name: "4.1.1.1 | AUDIT | Stat /etc/crontab"
+      ansible.builtin.stat:
+        path: /etc/crontab
+      register: cis_4_1_1_1_crontab
+      changed_when: >-
+        not cis_4_1_1_1_crontab.stat.exists or
+        cis_4_1_1_1_crontab.stat.pw_name != 'root' or
+        cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
+        (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
+      failed_when: false
+      check_mode: false
+
+    - name: "4.1.1.1 | AUDIT | Report /etc/crontab permission state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: /etc/crontab owner=' ~
+             (cis_4_1_1_1_crontab.stat.pw_name | default('?')) ~ ' group=' ~
+             (cis_4_1_1_1_crontab.stat.gr_name | default('?')) ~ ' mode=' ~
+             (cis_4_1_1_1_crontab.stat.mode | default('?')) ~
+             ' — expected root:wheel with no group/other permissions'
+             if cis_4_1_1_1_crontab is changed
+             else 'COMPLIANT: /etc/crontab is root:wheel with no group/other permissions' }}
+
+    - name: "4.1.1.1 | REMEDIATE | Set /etc/crontab owner, group, and mode"
+      ansible.builtin.file:
+        path: /etc/crontab
+        owner: root
+        group: wheel
+        mode: '0600'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_1_1_crontab is changed
+
+# ---
+
+- name: "4.1.1.2 | Ensure permissions on /etc/cron.d are configured"
+  when: "'4.1.1.2' not in active_exceptions"
+  tags: [rule_4.1.1.2, level1, section_4, automated]
+  block:
+
+    - name: "4.1.1.2 | AUDIT | Stat /etc/cron.d"
+      ansible.builtin.stat:
+        path: /etc/cron.d
+      register: cis_4_1_1_2_crond
+      changed_when: >-
+        not cis_4_1_1_2_crond.stat.exists or
+        cis_4_1_1_2_crond.stat.pw_name != 'root' or
+        cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
+        (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
+      failed_when: false
+      check_mode: false
+
+    - name: "4.1.1.2 | AUDIT | Report /etc/cron.d permission state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: /etc/cron.d owner=' ~
+             (cis_4_1_1_2_crond.stat.pw_name | default('?')) ~ ' group=' ~
+             (cis_4_1_1_2_crond.stat.gr_name | default('?')) ~ ' mode=' ~
+             (cis_4_1_1_2_crond.stat.mode | default('?')) ~
+             ' — expected root:wheel with no group/other permissions'
+             if cis_4_1_1_2_crond is changed
+             else 'COMPLIANT: /etc/cron.d is root:wheel with no group/other permissions' }}
+
+    - name: "4.1.1.2 | REMEDIATE | Set /etc/cron.d owner, group, and mode"
+      ansible.builtin.file:
+        path: /etc/cron.d
+        owner: root
+        group: wheel
+        mode: '0700'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_1_2_crond is changed
+
+# ---
+
+- name: "4.1.1.3 | Ensure crontab is restricted to authorized users"
+  when: "'4.1.1.3' not in active_exceptions"
+  tags: [rule_4.1.1.3, level1, section_4, manual]
+  block:
+
+    - name: "4.1.1.3 | AUDIT | Stat /var/cron/allow"
+      ansible.builtin.stat:
+        path: /var/cron/allow
+      register: cis_4_1_1_3_allow
+      check_mode: false
+
+    - name: "4.1.1.3 | AUDIT | Stat /var/cron/deny"
+      ansible.builtin.stat:
+        path: /var/cron/deny
+      register: cis_4_1_1_3_deny
+      check_mode: false
+
+    - name: "4.1.1.3 | AUDIT | Evaluate cron access control state"
+      ansible.builtin.set_fact:
+        cis_4_1_1_3_allow_ok: >-
+          {{ cis_4_1_1_3_allow.stat.exists and
+             cis_4_1_1_3_allow.stat.pw_name == 'root' and
+             cis_4_1_1_3_allow.stat.gr_name == 'wheel' and
+             (cis_4_1_1_3_allow.stat.mode | int(base=8)) % 8 == 0 and
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+        cis_4_1_1_3_deny_ok: >-
+          {{ not cis_4_1_1_3_deny.stat.exists or
+             (cis_4_1_1_3_deny.stat.pw_name == 'root' and
+              cis_4_1_1_3_deny.stat.gr_name == 'wheel' and
+              (cis_4_1_1_3_deny.stat.mode | int(base=8)) % 8 == 0 and
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+      changed_when: not (cis_4_1_1_3_allow_ok | bool) or not (cis_4_1_1_3_deny_ok | bool)
+      check_mode: false
+
+    - name: "4.1.1.3 | AUDIT | Report cron access control state"
+      ansible.builtin.debug:
+        msg: "{{ ['4.1.1.3 cron access control:', ''] +
+              ['  /var/cron/allow: ' ~ ('OK' if cis_4_1_1_3_allow_ok else 'NON-COMPLIANT — missing or wrong owner/mode'),
+               '  /var/cron/deny: ' ~ ('OK or absent' if cis_4_1_1_3_deny_ok else 'NON-COMPLIANT — wrong owner/mode'),
+               '',
+               'COMPLIANT: cron access controls are properly configured'
+               if (cis_4_1_1_3_allow_ok | bool) and (cis_4_1_1_3_deny_ok | bool)
+               else 'NON-COMPLIANT: see details above — review /var/cron/allow contents per site policy'] }}"
+
+    - name: "4.1.1.3 | REMEDIATE | Create /var/cron/allow if absent"
+      ansible.builtin.file:
+        path: /var/cron/allow
+        state: touch
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - not cis_4_1_1_3_allow.stat.exists
+
+    - name: "4.1.1.3 | REMEDIATE | Fix /var/cron/allow permissions"
+      ansible.builtin.file:
+        path: /var/cron/allow
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_1_3_allow.stat.exists
+        - not (cis_4_1_1_3_allow_ok | bool)
+
+    - name: "4.1.1.3 | REMEDIATE | Fix /var/cron/deny permissions if present"
+      ansible.builtin.file:
+        path: /var/cron/deny
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_1_3_deny.stat.exists
+        - not (cis_4_1_1_3_deny_ok | bool)
+
+# ---
+
+- name: "4.1.2.1 | Ensure at is restricted to authorized users"
+  when: "'4.1.2.1' not in active_exceptions"
+  tags: [rule_4.1.2.1, level1, section_4, manual]
+  block:
+
+    - name: "4.1.2.1 | AUDIT | Stat /var/at/at.allow"
+      ansible.builtin.stat:
+        path: /var/at/at.allow
+      register: cis_4_1_2_1_allow
+      check_mode: false
+
+    - name: "4.1.2.1 | AUDIT | Stat /var/at/at.deny"
+      ansible.builtin.stat:
+        path: /var/at/at.deny
+      register: cis_4_1_2_1_deny
+      check_mode: false
+
+    - name: "4.1.2.1 | AUDIT | Evaluate at access control state"
+      ansible.builtin.set_fact:
+        cis_4_1_2_1_allow_ok: >-
+          {{ cis_4_1_2_1_allow.stat.exists and
+             cis_4_1_2_1_allow.stat.pw_name in ['root', 'daemon'] and
+             cis_4_1_2_1_allow.stat.gr_name == 'wheel' and
+             (cis_4_1_2_1_allow.stat.mode | int(base=8)) % 8 == 0 and
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+        cis_4_1_2_1_deny_ok: >-
+          {{ not cis_4_1_2_1_deny.stat.exists or
+             (cis_4_1_2_1_deny.stat.pw_name in ['root', 'daemon'] and
+              cis_4_1_2_1_deny.stat.gr_name == 'wheel' and
+              (cis_4_1_2_1_deny.stat.mode | int(base=8)) % 8 == 0 and
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+      changed_when: not (cis_4_1_2_1_allow_ok | bool) or not (cis_4_1_2_1_deny_ok | bool)
+      check_mode: false
+
+    - name: "4.1.2.1 | AUDIT | Report at access control state"
+      ansible.builtin.debug:
+        msg: "{{ ['4.1.2.1 at access control:', ''] +
+              ['  /var/at/at.allow: ' ~ ('OK' if cis_4_1_2_1_allow_ok else 'NON-COMPLIANT — missing or wrong owner/mode'),
+               '  /var/at/at.deny: ' ~ ('OK or absent' if cis_4_1_2_1_deny_ok else 'NON-COMPLIANT — wrong owner/mode'),
+               '',
+               'COMPLIANT: at access controls are properly configured'
+               if (cis_4_1_2_1_allow_ok | bool) and (cis_4_1_2_1_deny_ok | bool)
+               else 'NON-COMPLIANT: see details above — review /var/at/at.allow contents per site policy'] }}"
+
+    - name: "4.1.2.1 | REMEDIATE | Create /var/at/at.allow if absent"
+      ansible.builtin.file:
+        path: /var/at/at.allow
+        state: touch
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - not cis_4_1_2_1_allow.stat.exists
+
+    - name: "4.1.2.1 | REMEDIATE | Fix /var/at/at.allow permissions"
+      ansible.builtin.file:
+        path: /var/at/at.allow
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_2_1_allow.stat.exists
+        - not (cis_4_1_2_1_allow_ok | bool)
+
+    - name: "4.1.2.1 | REMEDIATE | Fix /var/at/at.deny permissions if present"
+      ansible.builtin.file:
+        path: /var/at/at.deny
+        owner: root
+        group: wheel
+        mode: '0640'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_1_2_1_deny.stat.exists
+        - not (cis_4_1_2_1_deny_ok | bool)
+
+# =============================================================
+# 4.2 Configure SSH Server
+# Pre-gather effective sshd configuration (reused by 4.2.4–4.2.21)
+# =============================================================
+
+- name: "4.2 | GATHER | Query sshd effective configuration via sshd -T"
+  ansible.builtin.command:
+    argv:
+      - "{{ freebsd_cis_sshd_bin }}"
+      - -T
+      - -C
+      - "user=root"
+      - -C
+      - "host={{ ansible_hostname }}"
+      - -C
+      - "addr={{ ansible_default_ipv4.address | default('127.0.0.1') }}"
+  register: cis_4_2_sshd_config_dump
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
+# ---
+
+- name: "4.2.1 | Ensure permissions on /etc/ssh/sshd_config are configured"
+  when: "'4.2.1' not in active_exceptions"
+  tags: [rule_4.2.1, level1, section_4]
+  block:
+
+    - name: "4.2.1 | AUDIT | Stat {{ freebsd_cis_sshd_config }}"
+      ansible.builtin.stat:
+        path: "{{ freebsd_cis_sshd_config }}"
+      register: cis_4_2_1_sshdcfg
+      changed_when: >-
+        not cis_4_2_1_sshdcfg.stat.exists or
+        cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
+        cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
+        (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
+      failed_when: false
+      check_mode: false
+
+    - name: "4.2.1 | AUDIT | Report sshd_config permission state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: ' ~ freebsd_cis_sshd_config ~ ' owner=' ~
+             (cis_4_2_1_sshdcfg.stat.pw_name | default('?')) ~ ' group=' ~
+             (cis_4_2_1_sshdcfg.stat.gr_name | default('?')) ~ ' mode=' ~
+             (cis_4_2_1_sshdcfg.stat.mode | default('?')) ~
+             ' — expected root:wheel mode 0600 or more restrictive'
+             if cis_4_2_1_sshdcfg is changed
+             else 'COMPLIANT: ' ~ freebsd_cis_sshd_config ~ ' has correct ownership and mode' }}
+
+    - name: "4.2.1 | REMEDIATE | Fix sshd_config permissions"
+      ansible.builtin.file:
+        path: "{{ freebsd_cis_sshd_config }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_1_sshdcfg is changed
+
+# ---
+
+- name: "4.2.2 | Ensure permissions on SSH private host key files are configured"
+  when: "'4.2.2' not in active_exceptions"
+  tags: [rule_4.2.2, level1, section_4]
+  block:
+
+    - name: "4.2.2 | AUDIT | Find SSH private host key files"
+      ansible.builtin.find:
+        paths: "{{ freebsd_cis_sshd_config | dirname }}"
+        patterns: "ssh_host_*_key"
+        file_type: file
+      register: cis_4_2_2_privkeys
+      check_mode: false
+
+    - name: "4.2.2 | AUDIT | Check private key permissions"
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop: "{{ cis_4_2_2_privkeys.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+      register: cis_4_2_2_privkey_stats
+      check_mode: false
+
+    - name: "4.2.2 | AUDIT | Report private key permission state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: ' ~ item.stat.path ~ ' owner=' ~
+             (item.stat.pw_name | default('?')) ~ ' group=' ~
+             (item.stat.gr_name | default('?')) ~ ' mode=' ~
+             (item.stat.mode | default('?')) ~
+             ' — expected root:wheel mode 0600'
+             if (item.stat.pw_name != 'root' or
+                 item.stat.gr_name != 'wheel' or
+                 (item.stat.mode | int(base=8)) % 64 != 0)
+             else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
+      loop: "{{ cis_4_2_2_privkey_stats.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
+
+    - name: "4.2.2 | REMEDIATE | Fix SSH private host key file permissions"
+      ansible.builtin.file:
+        path: "{{ item.stat.path }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      loop: "{{ cis_4_2_2_privkey_stats.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
+      when:
+        - freebsd_cis_remediate | bool
+        - item.stat.pw_name != 'root' or
+          item.stat.gr_name != 'wheel' or
+          (item.stat.mode | int(base=8)) % 64 != 0
+
+# ---
+
+- name: "4.2.3 | Ensure permissions on SSH public host key files are configured"
+  when: "'4.2.3' not in active_exceptions"
+  tags: [rule_4.2.3, level1, section_4]
+  block:
+
+    - name: "4.2.3 | AUDIT | Find SSH public host key files"
+      ansible.builtin.find:
+        paths: "{{ freebsd_cis_sshd_config | dirname }}"
+        patterns: "ssh_host_*_key.pub"
+        file_type: file
+      register: cis_4_2_3_pubkeys
+      check_mode: false
+
+    - name: "4.2.3 | AUDIT | Check public key permissions"
+      ansible.builtin.stat:
+        path: "{{ item.path }}"
+      loop: "{{ cis_4_2_3_pubkeys.files }}"
+      loop_control:
+        label: "{{ item.path }}"
+      register: cis_4_2_3_pubkey_stats
+      check_mode: false
+
+    - name: "4.2.3 | AUDIT | Report public key permission state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: ' ~ item.stat.path ~ ' owner=' ~
+             (item.stat.pw_name | default('?')) ~ ' group=' ~
+             (item.stat.gr_name | default('?')) ~ ' mode=' ~
+             (item.stat.mode | default('?')) ~
+             ' — expected root:wheel mode 0644'
+             if (item.stat.pw_name != 'root' or
+                 item.stat.gr_name != 'wheel' or
+                 (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
+                 ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4])
+             else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
+      loop: "{{ cis_4_2_3_pubkey_stats.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
+
+    - name: "4.2.3 | REMEDIATE | Fix SSH public host key file permissions"
+      ansible.builtin.file:
+        path: "{{ item.stat.path }}"
+        owner: root
+        group: wheel
+        mode: '0644'
+      loop: "{{ cis_4_2_3_pubkey_stats.results }}"
+      loop_control:
+        label: "{{ item.stat.path }}"
+      when:
+        - freebsd_cis_remediate | bool
+        - item.stat.pw_name != 'root' or
+          item.stat.gr_name != 'wheel' or
+          (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
+          ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4]
+
+# ---
+
+- name: "4.2.4 | Ensure sshd access is configured"
+  when: "'4.2.4' not in active_exceptions"
+  tags: [rule_4.2.4, level1, section_4, manual]
+  block:
+
+    - name: "4.2.4 | AUDIT | Check for access control directives in effective config"
+      ansible.builtin.set_fact:
+        cis_4_2_4_access_configured: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^(allowusers|allowgroups|denyusers|denygroups)\s')
+             | list | length > 0 }}
+      changed_when: not (cis_4_2_4_access_configured | bool)
+      check_mode: false
+
+    - name: "4.2.4 | AUDIT | Report sshd access control state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: at least one sshd access control directive is configured'
+             if cis_4_2_4_access_configured | bool
+             else 'NON-COMPLIANT: no AllowUsers/AllowGroups/DenyUsers/DenyGroups directive found — set at least one per site policy' }}
+
+    - name: "4.2.4 | REMEDIATE | Set AllowUsers if configured"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*AllowUsers\s'
+        line: "AllowUsers {{ freebsd_cis_sshd_allow_users }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - freebsd_cis_sshd_allow_users | length > 0
+
+    - name: "4.2.4 | REMEDIATE | Set AllowGroups if configured"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*AllowGroups\s'
+        line: "AllowGroups {{ freebsd_cis_sshd_allow_groups }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - freebsd_cis_sshd_allow_groups | length > 0
+
+    - name: "4.2.4 | REMEDIATE | Set DenyUsers if configured"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*DenyUsers\s'
+        line: "DenyUsers {{ freebsd_cis_sshd_deny_users }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - freebsd_cis_sshd_deny_users | length > 0
+
+    - name: "4.2.4 | REMEDIATE | Set DenyGroups if configured"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*DenyGroups\s'
+        line: "DenyGroups {{ freebsd_cis_sshd_deny_groups }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - freebsd_cis_sshd_deny_groups | length > 0
+
+# ---
+
+- name: "4.2.5 | Ensure sshd Banner is configured"
+  when: "'4.2.5' not in active_exceptions"
+  tags: [rule_4.2.5, level1, section_4, manual]
+  block:
+
+    - name: "4.2.5 | AUDIT | Check Banner directive"
+      ansible.builtin.set_fact:
+        cis_4_2_5_banner_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^banner\s')
+             | list | first | default('banner none')
+             | regex_replace('^banner\s+', '') | trim }}
+      changed_when: cis_4_2_5_banner_val != freebsd_cis_sshd_banner
+      check_mode: false
+
+    - name: "4.2.5 | AUDIT | Report Banner state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: Banner is set to ' ~ cis_4_2_5_banner_val
+             if cis_4_2_5_banner_val == freebsd_cis_sshd_banner
+             else 'NON-COMPLIANT: Banner=' ~ cis_4_2_5_banner_val ~
+                  ' — expected ' ~ freebsd_cis_sshd_banner }}
+
+    - name: "4.2.5 | REMEDIATE | Set Banner in sshd_config"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*Banner\s'
+        line: "Banner {{ freebsd_cis_sshd_banner }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_5_banner_val != freebsd_cis_sshd_banner
+
+# ---
+
+- name: "4.2.6 | Ensure sshd Ciphers are configured"
+  when: "'4.2.6' not in active_exceptions"
+  tags: [rule_4.2.6, level1, section_4, manual]
+  block:
+
+    - name: "4.2.6 | AUDIT | Extract effective cipher list"
+      ansible.builtin.set_fact:
+        cis_4_2_6_ciphers: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^ciphers\s')
+             | list | first | default('ciphers')
+             | regex_replace('^ciphers\s+', '') | trim }}
+      check_mode: false
+
+    - name: "4.2.6 | AUDIT | Check for weak ciphers"
+      ansible.builtin.set_fact:
+        cis_4_2_6_weak_found: >-
+          {{ freebsd_cis_sshd_weak_ciphers.split(',')
+             | select('in', cis_4_2_6_ciphers) | list }}
+      changed_when: cis_4_2_6_weak_found | length > 0
+      check_mode: false
+
+    - name: "4.2.6 | AUDIT | Report Ciphers state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: weak ciphers present: ' ~ cis_4_2_6_weak_found | join(', ')
+             if cis_4_2_6_weak_found | length > 0
+             else 'COMPLIANT: no weak ciphers detected in effective cipher list' }}
+
+    - name: "4.2.6 | REMEDIATE | Remove weak ciphers from sshd_config"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*Ciphers\s'
+        line: "Ciphers -{{ freebsd_cis_sshd_weak_ciphers }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_6_weak_found | length > 0
+
+# ---
+
+- name: "4.2.7 | Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured"
+  when: "'4.2.7' not in active_exceptions"
+  tags: [rule_4.2.7, level1, section_4, manual]
+  block:
+
+    - name: "4.2.7 | AUDIT | Extract ClientAlive values"
+      ansible.builtin.set_fact:
+        cis_4_2_7_interval: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^clientaliveinterval\s')
+             | list | first | default('clientaliveinterval 0')
+             | regex_replace('^clientaliveinterval\s+', '') | trim | int }}
+        cis_4_2_7_countmax: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^clientalivecountmax\s')
+             | list | first | default('clientalivecountmax 3')
+             | regex_replace('^clientalivecountmax\s+', '') | trim | int }}
+      changed_when: >-
+        (cis_4_2_7_interval | int) == 0 or (cis_4_2_7_countmax | int) == 0
+      check_mode: false
+
+    - name: "4.2.7 | AUDIT | Report ClientAlive state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: ClientAliveInterval=' ~ cis_4_2_7_interval ~
+             ' ClientAliveCountMax=' ~ cis_4_2_7_countmax ~
+             ' — both must be > 0'
+             if (cis_4_2_7_interval | int) == 0 or (cis_4_2_7_countmax | int) == 0
+             else 'COMPLIANT: ClientAliveInterval=' ~ cis_4_2_7_interval ~
+                  ' ClientAliveCountMax=' ~ cis_4_2_7_countmax }}
+
+    - name: "4.2.7 | REMEDIATE | Set ClientAliveInterval"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*ClientAliveInterval\s'
+        line: "ClientAliveInterval {{ freebsd_cis_sshd_client_alive_interval }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_7_interval | int) == 0
+
+    - name: "4.2.7 | REMEDIATE | Set ClientAliveCountMax"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*ClientAliveCountMax\s'
+        line: "ClientAliveCountMax {{ freebsd_cis_sshd_client_alive_count_max }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_7_countmax | int) == 0
+
+# ---
+
+- name: "4.2.8 | Ensure sshd DisableForwarding is enabled"
+  when: "'4.2.8' not in active_exceptions"
+  tags: [rule_4.2.8, level1, section_4, manual]
+  block:
+
+    - name: "4.2.8 | AUDIT | Check DisableForwarding"
+      ansible.builtin.set_fact:
+        cis_4_2_8_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^disableforwarding\s')
+             | list | first | default('disableforwarding no')
+             | regex_replace('^disableforwarding\s+', '') | trim }}
+      changed_when: cis_4_2_8_val != 'yes'
+      check_mode: false
+
+    - name: "4.2.8 | AUDIT | Report DisableForwarding state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: DisableForwarding=yes'
+             if cis_4_2_8_val == 'yes'
+             else 'NON-COMPLIANT: DisableForwarding=' ~ cis_4_2_8_val ~ ' — expected yes' }}
+
+    - name: "4.2.8 | REMEDIATE | Set DisableForwarding yes"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*DisableForwarding\s'
+        line: 'DisableForwarding yes'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_8_val != 'yes'
+
+# ---
+
+- name: "4.2.9 | Ensure sshd HostbasedAuthentication is disabled"
+  when: "'4.2.9' not in active_exceptions"
+  tags: [rule_4.2.9, level1, section_4, manual]
+  block:
+
+    - name: "4.2.9 | AUDIT | Check HostbasedAuthentication"
+      ansible.builtin.set_fact:
+        cis_4_2_9_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^hostbasedauthentication\s')
+             | list | first | default('hostbasedauthentication no')
+             | regex_replace('^hostbasedauthentication\s+', '') | trim }}
+      changed_when: cis_4_2_9_val != 'no'
+      check_mode: false
+
+    - name: "4.2.9 | AUDIT | Report HostbasedAuthentication state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: HostbasedAuthentication=no'
+             if cis_4_2_9_val == 'no'
+             else 'NON-COMPLIANT: HostbasedAuthentication=' ~ cis_4_2_9_val ~ ' — expected no' }}
+
+    - name: "4.2.9 | REMEDIATE | Set HostbasedAuthentication no"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*HostbasedAuthentication\s'
+        line: 'HostbasedAuthentication no'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_9_val != 'no'
+
+# ---
+
+- name: "4.2.10 | Ensure sshd IgnoreRhosts is enabled"
+  when: "'4.2.10' not in active_exceptions"
+  tags: [rule_4.2.10, level1, section_4, manual]
+  block:
+
+    - name: "4.2.10 | AUDIT | Check IgnoreRhosts"
+      ansible.builtin.set_fact:
+        cis_4_2_10_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^ignorerhosts\s')
+             | list | first | default('ignorerhosts yes')
+             | regex_replace('^ignorerhosts\s+', '') | trim }}
+      changed_when: cis_4_2_10_val != 'yes'
+      check_mode: false
+
+    - name: "4.2.10 | AUDIT | Report IgnoreRhosts state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: IgnoreRhosts=yes'
+             if cis_4_2_10_val == 'yes'
+             else 'NON-COMPLIANT: IgnoreRhosts=' ~ cis_4_2_10_val ~ ' — expected yes' }}
+
+    - name: "4.2.10 | REMEDIATE | Set IgnoreRhosts yes"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*IgnoreRhosts\s'
+        line: 'IgnoreRhosts yes'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_10_val != 'yes'
+
+# ---
+
+- name: "4.2.11 | Ensure sshd KexAlgorithms is configured"
+  when: "'4.2.11' not in active_exceptions"
+  tags: [rule_4.2.11, level1, section_4, manual]
+  block:
+
+    - name: "4.2.11 | AUDIT | Extract effective KexAlgorithms"
+      ansible.builtin.set_fact:
+        cis_4_2_11_kex: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^kexalgorithms\s')
+             | list | first | default('kexalgorithms')
+             | regex_replace('^kexalgorithms\s+', '') | trim }}
+      check_mode: false
+
+    - name: "4.2.11 | AUDIT | Check for weak KexAlgorithms"
+      ansible.builtin.set_fact:
+        cis_4_2_11_weak_found: >-
+          {{ freebsd_cis_sshd_weak_kex.split(',')
+             | select('in', cis_4_2_11_kex) | list }}
+      changed_when: cis_4_2_11_weak_found | length > 0
+      check_mode: false
+
+    - name: "4.2.11 | AUDIT | Report KexAlgorithms state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: weak KexAlgorithms present: ' ~ cis_4_2_11_weak_found | join(', ')
+             if cis_4_2_11_weak_found | length > 0
+             else 'COMPLIANT: no weak KexAlgorithms detected in effective list' }}
+
+    - name: "4.2.11 | REMEDIATE | Remove weak KexAlgorithms from sshd_config"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*KexAlgorithms\s'
+        line: "KexAlgorithms -{{ freebsd_cis_sshd_weak_kex }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_11_weak_found | length > 0
+
+# ---
+
+- name: "4.2.12 | Ensure sshd LoginGraceTime is configured"
+  when: "'4.2.12' not in active_exceptions"
+  tags: [rule_4.2.12, level1, section_4, manual]
+  block:
+
+    - name: "4.2.12 | AUDIT | Check LoginGraceTime"
+      ansible.builtin.set_fact:
+        cis_4_2_12_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^logingracetime\s')
+             | list | first | default('logingracetime 120')
+             | regex_replace('^logingracetime\s+', '') | trim | int }}
+      changed_when: (cis_4_2_12_val | int) == 0 or (cis_4_2_12_val | int) > 60
+      check_mode: false
+
+    - name: "4.2.12 | AUDIT | Report LoginGraceTime state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: LoginGraceTime=' ~ cis_4_2_12_val ~
+             ' — expected 1-60 seconds'
+             if (cis_4_2_12_val | int) == 0 or (cis_4_2_12_val | int) > 60
+             else 'COMPLIANT: LoginGraceTime=' ~ cis_4_2_12_val }}
+
+    - name: "4.2.12 | REMEDIATE | Set LoginGraceTime"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*LoginGraceTime\s'
+        line: "LoginGraceTime {{ freebsd_cis_sshd_login_grace_time }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_12_val | int) == 0 or (cis_4_2_12_val | int) > 60
+
+# ---
+
+- name: "4.2.13 | Ensure sshd LogLevel is configured"
+  when: "'4.2.13' not in active_exceptions"
+  tags: [rule_4.2.13, level1, section_4, manual]
+  block:
+
+    - name: "4.2.13 | AUDIT | Check LogLevel"
+      ansible.builtin.set_fact:
+        cis_4_2_13_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^loglevel\s')
+             | list | first | default('loglevel INFO')
+             | regex_replace('^loglevel\s+', '') | trim | upper }}
+      changed_when: cis_4_2_13_val not in ['INFO', 'VERBOSE']
+      check_mode: false
+
+    - name: "4.2.13 | AUDIT | Report LogLevel state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: LogLevel=' ~ cis_4_2_13_val
+             if cis_4_2_13_val in ['INFO', 'VERBOSE']
+             else 'NON-COMPLIANT: LogLevel=' ~ cis_4_2_13_val ~ ' — expected INFO or VERBOSE' }}
+
+    - name: "4.2.13 | REMEDIATE | Set LogLevel"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*LogLevel\s'
+        line: "LogLevel {{ freebsd_cis_sshd_log_level }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_13_val not in ['INFO', 'VERBOSE']
+
+# ---
+
+- name: "4.2.14 | Ensure sshd MACs are configured"
+  when: "'4.2.14' not in active_exceptions"
+  tags: [rule_4.2.14, level1, section_4, manual]
+  block:
+
+    - name: "4.2.14 | AUDIT | Extract effective MACs list"
+      ansible.builtin.set_fact:
+        cis_4_2_14_macs: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^macs\s')
+             | list | first | default('macs')
+             | regex_replace('^macs\s+', '') | trim }}
+      check_mode: false
+
+    - name: "4.2.14 | AUDIT | Check for weak MACs"
+      ansible.builtin.set_fact:
+        cis_4_2_14_weak_found: >-
+          {{ freebsd_cis_sshd_weak_macs.split(',')
+             | select('in', cis_4_2_14_macs) | list }}
+      changed_when: cis_4_2_14_weak_found | length > 0
+      check_mode: false
+
+    - name: "4.2.14 | AUDIT | Report MACs state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: weak MACs present: ' ~ cis_4_2_14_weak_found | join(', ')
+             if cis_4_2_14_weak_found | length > 0
+             else 'COMPLIANT: no weak MACs detected in effective list' }}
+
+    - name: "4.2.14 | REMEDIATE | Remove weak MACs from sshd_config"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*MACs\s'
+        line: "MACs -{{ freebsd_cis_sshd_weak_macs }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_14_weak_found | length > 0
+
+# ---
+
+- name: "4.2.15 | Ensure sshd MaxAuthTries is configured"
+  when: "'4.2.15' not in active_exceptions"
+  tags: [rule_4.2.15, level1, section_4, manual]
+  block:
+
+    - name: "4.2.15 | AUDIT | Check MaxAuthTries"
+      ansible.builtin.set_fact:
+        cis_4_2_15_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^maxauthtries\s')
+             | list | first | default('maxauthtries 6')
+             | regex_replace('^maxauthtries\s+', '') | trim | int }}
+      changed_when: (cis_4_2_15_val | int) > 4
+      check_mode: false
+
+    - name: "4.2.15 | AUDIT | Report MaxAuthTries state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: MaxAuthTries=' ~ cis_4_2_15_val ~ ' — expected 4 or less'
+             if (cis_4_2_15_val | int) > 4
+             else 'COMPLIANT: MaxAuthTries=' ~ cis_4_2_15_val }}
+
+    - name: "4.2.15 | REMEDIATE | Set MaxAuthTries"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*MaxAuthTries\s'
+        line: "MaxAuthTries {{ freebsd_cis_sshd_max_auth_tries }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_15_val | int) > 4
+
+# ---
+
+- name: "4.2.16 | Ensure sshd MaxSessions is configured"
+  when: "'4.2.16' not in active_exceptions"
+  tags: [rule_4.2.16, level1, section_4, manual]
+  block:
+
+    - name: "4.2.16 | AUDIT | Check MaxSessions"
+      ansible.builtin.set_fact:
+        cis_4_2_16_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^maxsessions\s')
+             | list | first | default('maxsessions 10')
+             | regex_replace('^maxsessions\s+', '') | trim | int }}
+      changed_when: (cis_4_2_16_val | int) > 10
+      check_mode: false
+
+    - name: "4.2.16 | AUDIT | Report MaxSessions state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: MaxSessions=' ~ cis_4_2_16_val ~ ' — expected 10 or less'
+             if (cis_4_2_16_val | int) > 10
+             else 'COMPLIANT: MaxSessions=' ~ cis_4_2_16_val }}
+
+    - name: "4.2.16 | REMEDIATE | Set MaxSessions"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*MaxSessions\s'
+        line: "MaxSessions {{ freebsd_cis_sshd_max_sessions }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_16_val | int) > 10
+
+# ---
+
+- name: "4.2.17 | Ensure sshd MaxStartups is configured"
+  when: "'4.2.17' not in active_exceptions"
+  tags: [rule_4.2.17, level1, section_4, manual]
+  block:
+
+    - name: "4.2.17 | AUDIT | Extract MaxStartups effective value"
+      ansible.builtin.set_fact:
+        cis_4_2_17_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^maxstartups\s')
+             | list | first | default('maxstartups 10:30:100')
+             | regex_replace('^maxstartups\s+', '') | trim }}
+      check_mode: false
+
+    - name: "4.2.17 | AUDIT | Parse MaxStartups components"
+      ansible.builtin.set_fact:
+        cis_4_2_17_start: "{{ cis_4_2_17_val.split(':')[0] | int }}"
+        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 100 }}"
+        cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else 100 }}"
+      changed_when: >-
+        (cis_4_2_17_start | int) > 10 or
+        (cis_4_2_17_rate | int) > 30 or
+        (cis_4_2_17_full | int) > 60
+      check_mode: false
+
+    - name: "4.2.17 | AUDIT | Report MaxStartups state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: MaxStartups=' ~ cis_4_2_17_val ~
+             ' — expected 10:30:60 or more restrictive (start<=10, rate<=30, full<=60)'
+             if (cis_4_2_17_start | int) > 10 or
+                (cis_4_2_17_rate | int) > 30 or
+                (cis_4_2_17_full | int) > 60
+             else 'COMPLIANT: MaxStartups=' ~ cis_4_2_17_val }}
+
+    - name: "4.2.17 | REMEDIATE | Set MaxStartups"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*MaxStartups\s'
+        line: "MaxStartups {{ freebsd_cis_sshd_max_startups }}"
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - (cis_4_2_17_start | int) > 10 or
+          (cis_4_2_17_rate | int) > 30 or
+          (cis_4_2_17_full | int) > 60
+
+# ---
+
+- name: "4.2.18 | Ensure sshd PermitEmptyPasswords is disabled"
+  when: "'4.2.18' not in active_exceptions"
+  tags: [rule_4.2.18, level1, section_4, manual]
+  block:
+
+    - name: "4.2.18 | AUDIT | Check PermitEmptyPasswords"
+      ansible.builtin.set_fact:
+        cis_4_2_18_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^permitemptypasswords\s')
+             | list | first | default('permitemptypasswords no')
+             | regex_replace('^permitemptypasswords\s+', '') | trim }}
+      changed_when: cis_4_2_18_val != 'no'
+      check_mode: false
+
+    - name: "4.2.18 | AUDIT | Report PermitEmptyPasswords state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: PermitEmptyPasswords=no'
+             if cis_4_2_18_val == 'no'
+             else 'NON-COMPLIANT: PermitEmptyPasswords=' ~ cis_4_2_18_val ~ ' — expected no' }}
+
+    - name: "4.2.18 | REMEDIATE | Set PermitEmptyPasswords no"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*PermitEmptyPasswords\s'
+        line: 'PermitEmptyPasswords no'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_18_val != 'no'
+
+# ---
+
+- name: "4.2.19 | Ensure sshd PermitRootLogin is disabled"
+  when: "'4.2.19' not in active_exceptions"
+  tags: [rule_4.2.19, level1, section_4, manual]
+  block:
+
+    - name: "4.2.19 | AUDIT | Check PermitRootLogin"
+      ansible.builtin.set_fact:
+        cis_4_2_19_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^permitrootlogin\s')
+             | list | first | default('permitrootlogin no')
+             | regex_replace('^permitrootlogin\s+', '') | trim }}
+      changed_when: cis_4_2_19_val != 'no'
+      check_mode: false
+
+    - name: "4.2.19 | AUDIT | Report PermitRootLogin state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: PermitRootLogin=no'
+             if cis_4_2_19_val == 'no'
+             else 'NON-COMPLIANT: PermitRootLogin=' ~ cis_4_2_19_val ~ ' — expected no' }}
+
+    - name: "4.2.19 | REMEDIATE | Set PermitRootLogin no"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*PermitRootLogin\s'
+        line: 'PermitRootLogin no'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_19_val != 'no'
+
+# ---
+
+- name: "4.2.20 | Ensure sshd PermitUserEnvironment is disabled"
+  when: "'4.2.20' not in active_exceptions"
+  tags: [rule_4.2.20, level1, section_4, automated]
+  block:
+
+    - name: "4.2.20 | AUDIT | Check PermitUserEnvironment"
+      ansible.builtin.set_fact:
+        cis_4_2_20_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^permituserenvironment\s')
+             | list | first | default('permituserenvironment no')
+             | regex_replace('^permituserenvironment\s+', '') | trim }}
+      changed_when: cis_4_2_20_val != 'no'
+      check_mode: false
+
+    - name: "4.2.20 | AUDIT | Report PermitUserEnvironment state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: PermitUserEnvironment=no'
+             if cis_4_2_20_val == 'no'
+             else 'NON-COMPLIANT: PermitUserEnvironment=' ~ cis_4_2_20_val ~ ' — expected no' }}
+
+    - name: "4.2.20 | REMEDIATE | Set PermitUserEnvironment no"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*PermitUserEnvironment\s'
+        line: 'PermitUserEnvironment no'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_20_val != 'no'
+
+# ---
+
+- name: "4.2.21 | Ensure sshd UsePAM is enabled"
+  when: "'4.2.21' not in active_exceptions"
+  tags: [rule_4.2.21, level1, section_4, automated]
+  block:
+
+    - name: "4.2.21 | AUDIT | Check UsePAM"
+      ansible.builtin.set_fact:
+        cis_4_2_21_val: >-
+          {{ cis_4_2_sshd_config_dump.stdout_lines | default([])
+             | select('match', '^usepam\s')
+             | list | first | default('usepam yes')
+             | regex_replace('^usepam\s+', '') | trim }}
+      changed_when: cis_4_2_21_val != 'yes'
+      check_mode: false
+
+    - name: "4.2.21 | AUDIT | Report UsePAM state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: UsePAM=yes'
+             if cis_4_2_21_val == 'yes'
+             else 'NON-COMPLIANT: UsePAM=' ~ cis_4_2_21_val ~ ' — expected yes' }}
+
+    - name: "4.2.21 | REMEDIATE | Set UsePAM yes"
+      ansible.builtin.lineinfile:
+        path: "{{ freebsd_cis_sshd_config }}"
+        regexp: '^\s*#?\s*UsePAM\s'
+        line: 'UsePAM yes'
+        owner: root
+        group: wheel
+        mode: '0600'
+      notify: Reload sshd
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_2_21_val != 'yes'

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -68,7 +68,8 @@
         not cis_4_1_1_2_crond.stat.exists or
         cis_4_1_1_2_crond.stat.pw_name != 'root' or
         cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
-        (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
+        (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
+        ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) % 2 == 0
       failed_when: false
       check_mode: false
 
@@ -79,9 +80,9 @@
              (cis_4_1_1_2_crond.stat.pw_name | default('?')) ~ ' group=' ~
              (cis_4_1_1_2_crond.stat.gr_name | default('?')) ~ ' mode=' ~
              (cis_4_1_1_2_crond.stat.mode | default('?')) ~
-             ' — expected root:wheel with no group/other permissions'
+             ' — expected root:wheel mode 0700 (no group/other permissions, owner execute required)'
              if cis_4_1_1_2_crond is changed
-             else 'COMPLIANT: /etc/cron.d is root:wheel with no group/other permissions' }}
+             else 'COMPLIANT: /etc/cron.d is root:wheel 0700 (no group/other permissions, owner execute set)' }}
 
     - name: "4.1.1.2 | REMEDIATE | Set /etc/cron.d owner, group, and mode"
       ansible.builtin.file:
@@ -94,7 +95,8 @@
         - cis_4_1_1_2_crond.stat.exists
         - cis_4_1_1_2_crond.stat.pw_name != 'root' or
           cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
-          (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
+          (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
+          ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) % 2 == 0
 
 # ---
 
@@ -264,6 +266,10 @@
 # =============================================================
 
 - name: "4.2 | GATHER | Query sshd effective configuration via sshd -T"
+  when: >-
+    (['4.2.4', '4.2.5', '4.2.6', '4.2.7', '4.2.8', '4.2.9', '4.2.10',
+      '4.2.11', '4.2.12', '4.2.13', '4.2.14', '4.2.15', '4.2.16', '4.2.17',
+      '4.2.18', '4.2.19', '4.2.20', '4.2.21'] | difference(active_exceptions) | length) > 0
   ansible.builtin.command:
     argv:
       - "{{ freebsd_cis_sshd_bin }}"
@@ -302,6 +308,10 @@
     - rule_4.2.21
 
 - name: "4.2 | GATHER | Report sshd -T query status"
+  when: >-
+    (['4.2.4', '4.2.5', '4.2.6', '4.2.7', '4.2.8', '4.2.9', '4.2.10',
+      '4.2.11', '4.2.12', '4.2.13', '4.2.14', '4.2.15', '4.2.16', '4.2.17',
+      '4.2.18', '4.2.19', '4.2.20', '4.2.21'] | difference(active_exceptions) | length) > 0
   ansible.builtin.debug:
     msg: >-
       {{ 'NON-COMPLIANT: sshd -T query failed (rc=' ~ cis_4_2_sshd_config_dump.rc ~


### PR DESCRIPTION
## Summary

Implements **Section 4 Part A** — Access, Authentication and Authorization controls 4.1.1.1 through 4.2.21.

Also introduces:
- Three new path tunables in `defaults/main.yml` for FreeBSD base vs ports-installed OpenSSH
- sshd policy tunables for all configurable parameters
- `handlers/main.yml` with a `Reload sshd` handler

## Why

Section 4 covers cron/at job scheduler hardening and SSH server hardening. The PDF for this section exceeds single-context limits so it is split into two PRs; this PR covers the first half.

## Controls implemented

| Control | Level | Subject |
|---|---|---|
| 4.1.1.1 | L1 | Permissions on /etc/crontab (root:wheel, og-rwx) |
| 4.1.1.2 | L1 | Permissions on /etc/cron.d (root:wheel, og-rwx) |
| 4.1.1.3 | L1 | crontab restricted to authorized users (/var/cron/allow) |
| 4.1.2.1 | L1 | at restricted to authorized users (/var/at/at.allow) |
| 4.2.1 | L1 | Permissions on sshd_config (root:wheel, og-rwx) |
| 4.2.2 | L1 | SSH private host key file permissions (root:wheel, 0600) |
| 4.2.3 | L1 | SSH public host key file permissions (root:wheel, 0644) |
| 4.2.4 | L1 | sshd AllowUsers/AllowGroups/DenyUsers/DenyGroups |
| 4.2.5 | L1 | sshd Banner → /etc/issue.net |
| 4.2.6 | L1 | sshd Ciphers — remove weak CBC ciphers |
| 4.2.7 | L1 | sshd ClientAliveInterval and ClientAliveCountMax |
| 4.2.8 | L1 | sshd DisableForwarding yes |
| 4.2.9 | L1 | sshd HostbasedAuthentication no |
| 4.2.10 | L1 | sshd IgnoreRhosts yes |
| 4.2.11 | L1 | sshd KexAlgorithms — remove weak DH groups |
| 4.2.12 | L1 | sshd LoginGraceTime 1–60 |
| 4.2.13 | L1 | sshd LogLevel VERBOSE or INFO |
| 4.2.14 | L1 | sshd MACs — remove weak HMAC-MD5/ripemd160/96-bit |
| 4.2.15 | L1 | sshd MaxAuthTries ≤ 4 |
| 4.2.16 | L1 | sshd MaxSessions ≤ 10 |
| 4.2.17 | L1 | sshd MaxStartups 10:30:60 or more restrictive |
| 4.2.18 | L1 | sshd PermitEmptyPasswords no |
| 4.2.19 | L1 | sshd PermitRootLogin no |
| 4.2.20 | L1 | sshd PermitUserEnvironment no |
| 4.2.21 | L1 | sshd UsePAM yes |

## Design notes

- **Path tunables**: `freebsd_cis_sshd_config`, `freebsd_cis_sshd_bin`, `freebsd_cis_ssh_bin` default to FreeBSD base system paths; override for ports-installed OpenSSH (`/usr/local/...`).
- **sshd -T**: Run once before all 4.2.x blocks and registered as `cis_4_2_sshd_config_dump`. All parameter checks parse `stdout_lines` via Jinja2 `select('match', '^param\s')` — no shell pipes.
- **File permissions**: Mode checks use `% 64` (og-rwx test) and `% 8` / `(// 8) % 8` instead of bitwise `&` (not supported in Jinja2).
- **lineinfile mode**: All `lineinfile` tasks touching `freebsd_cis_sshd_config` explicitly set `owner: root`, `group: wheel`, `mode: '0600'`.
- **Reload sshd**: `notify: Reload sshd` on all lineinfile remediation tasks; handler is `failed_when: false` to tolerate sshd not running.
- **4.2.4**: Remediation only applied per directive if the corresponding default variable is non-empty; audit runs unconditionally.
- **Cipher/KexAlgorithm/MAC checks**: Use the effective list from `sshd -T` (already resolved, no `-` prefix syntax). Remediation writes the minus-prefix removal line to satisfy FreeBSD OpenSSH's additive remove syntax.

## Lint gate

```
ansible-lint tasks/section_4.yml
Passed: 0 failure(s), 1 warning(s) — profile: production   (complexity warning only)
```

## Validation performed

No remote run yet (pending merge of PRs #8). Lint passes at production profile.

## Risks and follow-ups

- 4.2.4 remediation requires operator to set at least one of `freebsd_cis_sshd_allow_users`, `freebsd_cis_sshd_allow_groups`, `freebsd_cis_sshd_deny_users`, `freebsd_cis_sshd_deny_groups` in their inventory — otherwise the non-compliant audit will fire but nothing is remediated.
- Section 4 Part B (remainder of section 4) will be in a follow-up PR.
