### PR TITLE
feat: CIS section 4 part B — sudo, PAM, user accounts (4.3–4.5)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -105,3 +105,33 @@ freebsd_cis_sshd_max_sessions: 10
 
 # 4.2.17 — MaxStartups throttle: start:rate:full (benchmark recommends 10:30:60).
 freebsd_cis_sshd_max_startups: "10:30:60"
+
+# -------------------------------------------------------------------
+# Section 4.3 — sudo / privilege escalation
+# -------------------------------------------------------------------
+
+# 4.3.3 — Path for the sudo log file.
+freebsd_cis_sudo_logfile: /var/log/sudo.log
+
+# 4.3.6 — sudo credential cache timeout in minutes (1–15).
+# A value of -1 disables the timeout (non-compliant). Default sudo value is 5.
+freebsd_cis_sudo_timeout: 15
+
+# -------------------------------------------------------------------
+# Section 4.4 — PAM
+# -------------------------------------------------------------------
+
+# 4.4.1.1.1 / 4.4.1.1.2 — pam_passwdqc minlen argument string.
+# Format: disabled,N1,N2,N3,N4 (see pam_passwdqc(8)).
+# N1 must be >= 14 per CIS benchmark.
+freebsd_cis_pam_passwdqc_minlen: "disabled,14,12,8,6"
+
+# -------------------------------------------------------------------
+# Section 4.5 — User accounts and environment
+# -------------------------------------------------------------------
+
+# 4.5.1.2 — Maximum password age in days (<= 365).
+freebsd_cis_pw_max_age: 365
+
+# 4.5.1.3 — Password expiration warning in days (>= 7).
+freebsd_cis_pw_warn_days: 7

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -23,6 +23,7 @@
         not cis_4_1_1_1_crontab.stat.exists or
         cis_4_1_1_1_crontab.stat.pw_name != 'root' or
         cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
+        ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
         (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
@@ -49,6 +50,7 @@
         - cis_4_1_1_1_crontab.stat.exists
         - cis_4_1_1_1_crontab.stat.pw_name != 'root' or
           cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
+          ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
 
 # ---
@@ -66,6 +68,7 @@
         not cis_4_1_1_2_crond.stat.exists or
         cis_4_1_1_2_crond.stat.pw_name != 'root' or
         cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
+        ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64) % 8 != 7 or
         (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
@@ -92,6 +95,7 @@
         - cis_4_1_1_2_crond.stat.exists
         - cis_4_1_1_2_crond.stat.pw_name != 'root' or
           cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
+          ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64) % 8 != 7 or
           (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
 
 # ---
@@ -120,13 +124,15 @@
              cis_4_1_1_3_allow.stat.pw_name == 'root' and
              cis_4_1_1_3_allow.stat.gr_name == 'wheel' and
              (cis_4_1_1_3_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
         cis_4_1_1_3_deny_ok: >-
           {{ not cis_4_1_1_3_deny.stat.exists or
              (cis_4_1_1_3_deny.stat.pw_name == 'root' and
               cis_4_1_1_3_deny.stat.gr_name == 'wheel' and
               (cis_4_1_1_3_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
       changed_when: not (cis_4_1_1_3_allow_ok | bool) or not (cis_4_1_1_3_deny_ok | bool)
       check_mode: false
 
@@ -199,13 +205,15 @@
              cis_4_1_2_1_allow.stat.pw_name in ['root', 'daemon'] and
              cis_4_1_2_1_allow.stat.gr_name == 'wheel' and
              (cis_4_1_2_1_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
         cis_4_1_2_1_deny_ok: >-
           {{ not cis_4_1_2_1_deny.stat.exists or
              (cis_4_1_2_1_deny.stat.pw_name in ['root', 'daemon'] and
               cis_4_1_2_1_deny.stat.gr_name == 'wheel' and
               (cis_4_1_2_1_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
       changed_when: not (cis_4_1_2_1_allow_ok | bool) or not (cis_4_1_2_1_deny_ok | bool)
       check_mode: false
 
@@ -277,7 +285,10 @@
     ('4.2.19' not in active_exceptions) or
     ('4.2.20' not in active_exceptions) or
     ('4.2.21' not in active_exceptions)
-  tags: [section_4]
+  tags: [rule_4.2.4, rule_4.2.5, rule_4.2.6, rule_4.2.7, rule_4.2.8, rule_4.2.9,
+         rule_4.2.10, rule_4.2.11, rule_4.2.12, rule_4.2.13, rule_4.2.14, rule_4.2.15,
+         rule_4.2.16, rule_4.2.17, rule_4.2.18, rule_4.2.19, rule_4.2.20, rule_4.2.21,
+         section_4]
   ansible.builtin.command:
     argv:
       - "{{ freebsd_cis_sshd_bin }}"
@@ -296,6 +307,29 @@
   check_mode: false
 
 - name: "4.2 | GATHER | Report sshd -T query status"
+  when: >-
+    ('4.2.4' not in active_exceptions) or
+    ('4.2.5' not in active_exceptions) or
+    ('4.2.6' not in active_exceptions) or
+    ('4.2.7' not in active_exceptions) or
+    ('4.2.8' not in active_exceptions) or
+    ('4.2.9' not in active_exceptions) or
+    ('4.2.10' not in active_exceptions) or
+    ('4.2.11' not in active_exceptions) or
+    ('4.2.12' not in active_exceptions) or
+    ('4.2.13' not in active_exceptions) or
+    ('4.2.14' not in active_exceptions) or
+    ('4.2.15' not in active_exceptions) or
+    ('4.2.16' not in active_exceptions) or
+    ('4.2.17' not in active_exceptions) or
+    ('4.2.18' not in active_exceptions) or
+    ('4.2.19' not in active_exceptions) or
+    ('4.2.20' not in active_exceptions) or
+    ('4.2.21' not in active_exceptions)
+  tags: [rule_4.2.4, rule_4.2.5, rule_4.2.6, rule_4.2.7, rule_4.2.8, rule_4.2.9,
+         rule_4.2.10, rule_4.2.11, rule_4.2.12, rule_4.2.13, rule_4.2.14, rule_4.2.15,
+         rule_4.2.16, rule_4.2.17, rule_4.2.18, rule_4.2.19, rule_4.2.20, rule_4.2.21,
+         section_4]
   ansible.builtin.debug:
     msg: >-
       {{ 'NON-COMPLIANT: sshd -T query failed (rc=' ~ cis_4_2_sshd_config_dump.rc ~
@@ -319,6 +353,7 @@
         not cis_4_2_1_sshdcfg.stat.exists or
         cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
         cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
+        ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
         (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
@@ -345,6 +380,7 @@
         - cis_4_2_1_sshdcfg.stat.exists
         - cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
           cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
+          ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
 
 # ---
@@ -414,6 +450,7 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
+          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (item.stat.mode | int(base=8)) % 64 != 0
 
 # ---
@@ -484,6 +521,7 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
+          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
           ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4]
 
@@ -853,6 +891,7 @@
              | list | first | default('kexalgorithms')
              | regex_replace('^kexalgorithms\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.11 | AUDIT | Check for weak KexAlgorithms"
@@ -979,6 +1018,7 @@
              | list | first | default('macs')
              | regex_replace('^macs\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.14 | AUDIT | Check for weak MACs"
@@ -1110,7 +1150,7 @@
       ansible.builtin.set_fact:
         cis_4_2_17_start: "{{ cis_4_2_17_val.split(':')[0] | int }}"
         cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 0 }}"
-        cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else 100 }}"
+        cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else (cis_4_2_17_val.split(':')[0] | int) }}"
       changed_when: >-
         (cis_4_2_17_start | int) > 10 or
         (cis_4_2_17_rate | int) > 30 or
@@ -1411,7 +1451,7 @@
     - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
       ansible.builtin.command: grep -r '^[^#].*NOPASSWD' /usr/local/etc/sudoers
       register: cis_4_3_4_nopasswd
-      changed_when: cis_4_3_4_nopasswd.rc == 0
+      changed_when: cis_4_3_4_nopasswd.rc != 1
       failed_when: false
       check_mode: false
 
@@ -1421,7 +1461,10 @@
           {{ ['NON-COMPLIANT: NOPASSWD entries found — review and remove:']
              + cis_4_3_4_nopasswd.stdout_lines
              if cis_4_3_4_nopasswd.rc == 0
-             else 'COMPLIANT: no NOPASSWD entries found in sudoers' }}
+             else ('NON-COMPLIANT: grep error (rc=' ~ cis_4_3_4_nopasswd.rc ~
+                   ') — sudoers missing or unreadable'
+                   if cis_4_3_4_nopasswd.rc != 1
+                   else 'COMPLIANT: no NOPASSWD entries found in sudoers') }}
 
 # ---
 
@@ -1433,7 +1476,7 @@
     - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"
       ansible.builtin.command: grep -r '^[^#].*!authenticate' /usr/local/etc/sudoers
       register: cis_4_3_5_noauth
-      changed_when: cis_4_3_5_noauth.rc == 0
+      changed_when: cis_4_3_5_noauth.rc != 1
       failed_when: false
       check_mode: false
 
@@ -1443,7 +1486,10 @@
           {{ ['NON-COMPLIANT: !authenticate entries found — review and remove:']
              + cis_4_3_5_noauth.stdout_lines
              if cis_4_3_5_noauth.rc == 0
-             else 'COMPLIANT: no !authenticate entries found in sudoers' }}
+             else ('NON-COMPLIANT: grep error (rc=' ~ cis_4_3_5_noauth.rc ~
+                   ') — sudoers missing or unreadable'
+                   if cis_4_3_5_noauth.rc != 1
+                   else 'COMPLIANT: no !authenticate entries found in sudoers') }}
 
 # ---
 
@@ -1922,7 +1968,7 @@
     - name: "4.5.2.3 | AUDIT | Check system accounts with interactive shells"
       ansible.builtin.command:
         cmd: >-
-          awk -F: '($1!~/^(root|toor|uucp)$/ || $3 == 65533) &&
+          awk -F: '($3 < 1000 && $1!~/^(root|toor|uucp)$/) &&
           $7!~/^(\/usr)?\/sbin\/nologin$/ { print $1 }' /etc/passwd
       register: cis_4_5_2_3_shell
       changed_when: cis_4_5_2_3_shell.stdout != ''
@@ -1932,7 +1978,7 @@
     - name: "4.5.2.3 | AUDIT | Check nologin accounts with non-locked passwords"
       ansible.builtin.command:
         cmd: >-
-          awk -F: '($2!="*" && $7~/^(\/usr)?\/sbin\/nologin$/) { print $1 }'
+          awk -F: '($2!~/^\*/ && $7~/^(\/usr)?\/sbin\/nologin$/) { print $1 }'
           /etc/master.passwd
       register: cis_4_5_2_3_passwd
       changed_when: cis_4_5_2_3_passwd.stdout != ''

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1,7 +1,7 @@
 ---
 # FreeBSD 14 CIS Benchmark v1.0.1
-# Section 4 — Access, Authentication and Authorization (Part A)
-# Controls: 4.1.1.1 – 4.2.21
+# Section 4 — Access, Authentication and Authorization
+# Controls: 4.1.1.1 – 4.5.3.2
 # lint-clean: production profile
 
 # =============================================================
@@ -23,8 +23,7 @@
         not cis_4_1_1_1_crontab.stat.exists or
         cis_4_1_1_1_crontab.stat.pw_name != 'root' or
         cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
-        (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0 or
-        ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
+        (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
 
@@ -50,8 +49,7 @@
         - cis_4_1_1_1_crontab.stat.exists
         - cis_4_1_1_1_crontab.stat.pw_name != 'root' or
           cis_4_1_1_1_crontab.stat.gr_name != 'wheel' or
-          (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0 or
-          ((cis_4_1_1_1_crontab.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
+          (cis_4_1_1_1_crontab.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -68,8 +66,7 @@
         not cis_4_1_1_2_crond.stat.exists or
         cis_4_1_1_2_crond.stat.pw_name != 'root' or
         cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
-        (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
-        ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) != 7
+        (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
 
@@ -80,9 +77,9 @@
              (cis_4_1_1_2_crond.stat.pw_name | default('?')) ~ ' group=' ~
              (cis_4_1_1_2_crond.stat.gr_name | default('?')) ~ ' mode=' ~
              (cis_4_1_1_2_crond.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0700 (no group/other permissions, owner execute required)'
+             ' — expected root:wheel with no group/other permissions'
              if cis_4_1_1_2_crond is changed
-             else 'COMPLIANT: /etc/cron.d is root:wheel 0700 (no group/other permissions, owner execute set)' }}
+             else 'COMPLIANT: /etc/cron.d is root:wheel with no group/other permissions' }}
 
     - name: "4.1.1.2 | REMEDIATE | Set /etc/cron.d owner, group, and mode"
       ansible.builtin.file:
@@ -95,8 +92,7 @@
         - cis_4_1_1_2_crond.stat.exists
         - cis_4_1_1_2_crond.stat.pw_name != 'root' or
           cis_4_1_1_2_crond.stat.gr_name != 'wheel' or
-          (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0 or
-          ((cis_4_1_1_2_crond.stat.mode | int(base=8)) // 64 % 8) != 7
+          (cis_4_1_1_2_crond.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -124,15 +120,13 @@
              cis_4_1_1_3_allow.stat.pw_name == 'root' and
              cis_4_1_1_3_allow.stat.gr_name == 'wheel' and
              (cis_4_1_1_3_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
-             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
+             ((cis_4_1_1_3_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
         cis_4_1_1_3_deny_ok: >-
           {{ not cis_4_1_1_3_deny.stat.exists or
              (cis_4_1_1_3_deny.stat.pw_name == 'root' and
               cis_4_1_1_3_deny.stat.gr_name == 'wheel' and
               (cis_4_1_1_3_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
-              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
+              ((cis_4_1_1_3_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
       changed_when: not (cis_4_1_1_3_allow_ok | bool) or not (cis_4_1_1_3_deny_ok | bool)
       check_mode: false
 
@@ -205,15 +199,13 @@
              cis_4_1_2_1_allow.stat.pw_name in ['root', 'daemon'] and
              cis_4_1_2_1_allow.stat.gr_name == 'wheel' and
              (cis_4_1_2_1_allow.stat.mode | int(base=8)) % 8 == 0 and
-             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
-             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 64) % 8 in [4, 6] }}
+             ((cis_4_1_2_1_allow.stat.mode | int(base=8)) // 8) % 8 <= 4 }}
         cis_4_1_2_1_deny_ok: >-
           {{ not cis_4_1_2_1_deny.stat.exists or
              (cis_4_1_2_1_deny.stat.pw_name in ['root', 'daemon'] and
               cis_4_1_2_1_deny.stat.gr_name == 'wheel' and
               (cis_4_1_2_1_deny.stat.mode | int(base=8)) % 8 == 0 and
-              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 in [0, 4] and
-              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 64) % 8 in [4, 6]) }}
+              ((cis_4_1_2_1_deny.stat.mode | int(base=8)) // 8) % 8 <= 4) }}
       changed_when: not (cis_4_1_2_1_allow_ok | bool) or not (cis_4_1_2_1_deny_ok | bool)
       check_mode: false
 
@@ -266,52 +258,22 @@
 # =============================================================
 
 - name: "4.2 | GATHER | Query sshd effective configuration via sshd -T"
-  when: >-
-    (['4.2.4', '4.2.5', '4.2.6', '4.2.7', '4.2.8', '4.2.9', '4.2.10',
-      '4.2.11', '4.2.12', '4.2.13', '4.2.14', '4.2.15', '4.2.16', '4.2.17',
-      '4.2.18', '4.2.19', '4.2.20', '4.2.21'] | difference(active_exceptions) | length) > 0
   ansible.builtin.command:
     argv:
       - "{{ freebsd_cis_sshd_bin }}"
       - -T
-      - -f
-      - "{{ freebsd_cis_sshd_config }}"
       - -C
       - "user=root"
       - -C
       - "host={{ ansible_facts['hostname'] }}"
       - -C
-      - "addr={{ ((ansible_facts['default_ipv4'] | default({})).address) | default('127.0.0.1') }}"
+      - "addr={{ ansible_facts['default_ipv4']['address'] | default('127.0.0.1') }}"
   register: cis_4_2_sshd_config_dump
   changed_when: false
   failed_when: false
   check_mode: false
-  tags:
-    - section_4
-    - rule_4.2.4
-    - rule_4.2.5
-    - rule_4.2.6
-    - rule_4.2.7
-    - rule_4.2.8
-    - rule_4.2.9
-    - rule_4.2.10
-    - rule_4.2.11
-    - rule_4.2.12
-    - rule_4.2.13
-    - rule_4.2.14
-    - rule_4.2.15
-    - rule_4.2.16
-    - rule_4.2.17
-    - rule_4.2.18
-    - rule_4.2.19
-    - rule_4.2.20
-    - rule_4.2.21
 
 - name: "4.2 | GATHER | Report sshd -T query status"
-  when: >-
-    (['4.2.4', '4.2.5', '4.2.6', '4.2.7', '4.2.8', '4.2.9', '4.2.10',
-      '4.2.11', '4.2.12', '4.2.13', '4.2.14', '4.2.15', '4.2.16', '4.2.17',
-      '4.2.18', '4.2.19', '4.2.20', '4.2.21'] | difference(active_exceptions) | length) > 0
   ansible.builtin.debug:
     msg: >-
       {{ 'NON-COMPLIANT: sshd -T query failed (rc=' ~ cis_4_2_sshd_config_dump.rc ~
@@ -319,26 +281,6 @@
          if cis_4_2_sshd_config_dump.rc != 0
          else 'sshd -T: effective configuration query succeeded' }}
   changed_when: cis_4_2_sshd_config_dump.rc != 0
-  tags:
-    - section_4
-    - rule_4.2.4
-    - rule_4.2.5
-    - rule_4.2.6
-    - rule_4.2.7
-    - rule_4.2.8
-    - rule_4.2.9
-    - rule_4.2.10
-    - rule_4.2.11
-    - rule_4.2.12
-    - rule_4.2.13
-    - rule_4.2.14
-    - rule_4.2.15
-    - rule_4.2.16
-    - rule_4.2.17
-    - rule_4.2.18
-    - rule_4.2.19
-    - rule_4.2.20
-    - rule_4.2.21
 
 # ---
 
@@ -355,8 +297,7 @@
         not cis_4_2_1_sshdcfg.stat.exists or
         cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
         cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
-        (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0 or
-        ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
+        (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
       failed_when: false
       check_mode: false
 
@@ -382,8 +323,7 @@
         - cis_4_2_1_sshdcfg.stat.exists
         - cis_4_2_1_sshdcfg.stat.pw_name != 'root' or
           cis_4_2_1_sshdcfg.stat.gr_name != 'wheel' or
-          (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0 or
-          ((cis_4_2_1_sshdcfg.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
+          (cis_4_2_1_sshdcfg.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -398,7 +338,6 @@
         patterns: "ssh_host_*_key"
         file_type: file
       register: cis_4_2_2_privkeys
-      failed_when: false
       check_mode: false
 
     - name: "4.2.2 | AUDIT | Check private key permissions"
@@ -417,11 +356,10 @@
              (item.stat.pw_name | default('?')) ~ ' group=' ~
              (item.stat.gr_name | default('?')) ~ ' mode=' ~
              (item.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0600 or more restrictive (0400 permitted)'
+             ' — expected root:wheel mode 0600'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
-                 (item.stat.mode | int(base=8)) % 64 != 0 or
-                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6])
+                 (item.stat.mode | int(base=8)) % 64 != 0)
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
       loop: "{{ cis_4_2_2_privkey_stats.results }}"
       loop_control:
@@ -435,7 +373,7 @@
              or (cis_4_2_2_privkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_2_privkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[46]00$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[0-7]00$') | list | length > 0) }}
       changed_when: cis_4_2_2_non_compliant | bool
       check_mode: false
 
@@ -452,8 +390,7 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
-          (item.stat.mode | int(base=8)) % 64 != 0 or
-          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6]
+          (item.stat.mode | int(base=8)) % 64 != 0
 
 # ---
 
@@ -468,7 +405,6 @@
         patterns: "ssh_host_*_key.pub"
         file_type: file
       register: cis_4_2_3_pubkeys
-      failed_when: false
       check_mode: false
 
     - name: "4.2.3 | AUDIT | Check public key permissions"
@@ -487,10 +423,9 @@
              (item.stat.pw_name | default('?')) ~ ' group=' ~
              (item.stat.gr_name | default('?')) ~ ' mode=' ~
              (item.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0644 or more restrictive'
+             ' — expected root:wheel mode 0644'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
-                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
                  (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
                  ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4])
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
@@ -506,7 +441,7 @@
              or (cis_4_2_3_pubkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_3_pubkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[46][04][04]$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[0-7][04][04]$') | list | length > 0) }}
       changed_when: cis_4_2_3_non_compliant | bool
       check_mode: false
 
@@ -523,7 +458,6 @@
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
           item.stat.gr_name != 'wheel' or
-          ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
           (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
           ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4]
 
@@ -555,8 +489,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*AllowUsers\s'
         line: "AllowUsers {{ freebsd_cis_sshd_allow_users }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -570,8 +502,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*AllowGroups\s'
         line: "AllowGroups {{ freebsd_cis_sshd_allow_groups }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -585,8 +515,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DenyUsers\s'
         line: "DenyUsers {{ freebsd_cis_sshd_deny_users }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -600,8 +528,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DenyGroups\s'
         line: "DenyGroups {{ freebsd_cis_sshd_deny_groups }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -640,8 +566,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*Banner\s'
         line: "Banner {{ freebsd_cis_sshd_banner }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -665,7 +589,6 @@
              | list | first | default('ciphers')
              | regex_replace('^ciphers\s+', '') | trim).split(',')
              | map('trim') | list }}
-      changed_when: false
       check_mode: false
 
     - name: "4.2.6 | AUDIT | Check for weak ciphers"
@@ -688,8 +611,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*Ciphers\s'
         line: "Ciphers -{{ freebsd_cis_sshd_weak_ciphers }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -736,8 +657,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*ClientAliveInterval\s'
         line: "ClientAliveInterval {{ freebsd_cis_sshd_client_alive_interval }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -751,8 +670,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*ClientAliveCountMax\s'
         line: "ClientAliveCountMax {{ freebsd_cis_sshd_client_alive_count_max }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -790,8 +707,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*DisableForwarding\s'
         line: 'DisableForwarding yes'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -829,8 +744,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*HostbasedAuthentication\s'
         line: 'HostbasedAuthentication no'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -868,8 +781,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*IgnoreRhosts\s'
         line: 'IgnoreRhosts yes'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -893,7 +804,6 @@
              | list | first | default('kexalgorithms')
              | regex_replace('^kexalgorithms\s+', '') | trim).split(',')
              | map('trim') | list }}
-      changed_when: false
       check_mode: false
 
     - name: "4.2.11 | AUDIT | Check for weak KexAlgorithms"
@@ -916,8 +826,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*KexAlgorithms\s'
         line: "KexAlgorithms -{{ freebsd_cis_sshd_weak_kex }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -956,8 +864,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*LoginGraceTime\s'
         line: "LoginGraceTime {{ freebsd_cis_sshd_login_grace_time }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -995,8 +901,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*LogLevel\s'
         line: "LogLevel {{ freebsd_cis_sshd_log_level }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1020,7 +924,6 @@
              | list | first | default('macs')
              | regex_replace('^macs\s+', '') | trim).split(',')
              | map('trim') | list }}
-      changed_when: false
       check_mode: false
 
     - name: "4.2.14 | AUDIT | Check for weak MACs"
@@ -1043,8 +946,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MACs\s'
         line: "MACs -{{ freebsd_cis_sshd_weak_macs }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1082,8 +983,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxAuthTries\s'
         line: "MaxAuthTries {{ freebsd_cis_sshd_max_auth_tries }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1121,8 +1020,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxSessions\s'
         line: "MaxSessions {{ freebsd_cis_sshd_max_sessions }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1145,16 +1042,13 @@
              | select('match', '^maxstartups\s')
              | list | first | default('maxstartups 10:30:100')
              | regex_replace('^maxstartups\s+', '') | trim }}
-      changed_when: false
       check_mode: false
 
     - name: "4.2.17 | AUDIT | Parse MaxStartups components"
       ansible.builtin.set_fact:
         cis_4_2_17_start: "{{ cis_4_2_17_val.split(':')[0] | int }}"
-        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 0 }}"
-        cis_4_2_17_full: >-
-          {{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2
-             else (cis_4_2_17_val | int if ':' not in cis_4_2_17_val else 100) }}
+        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 100 }}"
+        cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else 100 }}"
       changed_when: >-
         (cis_4_2_17_start | int) > 10 or
         (cis_4_2_17_rate | int) > 30 or
@@ -1176,8 +1070,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*MaxStartups\s'
         line: "MaxStartups {{ freebsd_cis_sshd_max_startups }}"
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1217,8 +1109,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitEmptyPasswords\s'
         line: 'PermitEmptyPasswords no'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1256,8 +1146,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitRootLogin\s'
         line: 'PermitRootLogin no'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1295,8 +1183,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*PermitUserEnvironment\s'
         line: 'PermitUserEnvironment no'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1334,8 +1220,6 @@
         path: "{{ freebsd_cis_sshd_config }}"
         regexp: '^\s*#?\s*UsePAM\s'
         line: 'UsePAM yes'
-        insertbefore: '^\s*Match\b'
-        firstmatch: true
         owner: root
         group: wheel
         mode: '0600'
@@ -1343,3 +1227,647 @@
       when:
         - freebsd_cis_remediate | bool
         - cis_4_2_21_val != 'yes'
+
+# =============================================================
+# 4.3 Configure privilege escalation
+# =============================================================
+
+# ---
+
+- name: "4.3.1 | Ensure sudo is installed"
+  when: "'4.3.1' not in active_exceptions"
+  tags: [rule_4.3.1, level1, section_4, manual]
+  block:
+
+    - name: "4.3.1 | AUDIT | Check sudo package"
+      ansible.builtin.command: pkg info sudo
+      register: cis_4_3_1_sudo_pkg
+      changed_when: cis_4_3_1_sudo_pkg.rc != 0
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.1 | AUDIT | Report sudo installation state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: sudo is installed'
+             if cis_4_3_1_sudo_pkg.rc == 0
+             else 'NON-COMPLIANT: sudo is not installed' }}
+
+    - name: "4.3.1 | REMEDIATE | Install sudo"
+      ansible.builtin.package:
+        name: sudo
+        state: present
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_3_1_sudo_pkg.rc != 0
+
+# ---
+
+- name: "4.3.2 | Ensure sudo commands use pty"
+  when: "'4.3.2' not in active_exceptions"
+  tags: [rule_4.3.2, level1, section_4, automated]
+  block:
+
+    - name: "4.3.2 | AUDIT | Check Defaults use_pty in sudoers"
+      ansible.builtin.command: >-
+        grep -Ei '^[[:space:]]*Defaults[[:space:]]+([^#,]+,[[:space:]]*)?use_pty'
+        /usr/local/etc/sudoers
+      register: cis_4_3_2_use_pty
+      changed_when: cis_4_3_2_use_pty.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.2 | AUDIT | Report use_pty state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: Defaults use_pty is configured in sudoers'
+             if cis_4_3_2_use_pty.stdout != ''
+             else 'NON-COMPLIANT: Defaults use_pty is not configured in sudoers' }}
+
+    - name: "4.3.2 | REMEDIATE | Add Defaults use_pty to sudoers"
+      ansible.builtin.lineinfile:
+        path: /usr/local/etc/sudoers
+        regexp: '^\s*Defaults\s+use_pty'
+        line: 'Defaults use_pty'
+        validate: 'visudo -cf %s'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_3_2_use_pty.stdout == ''
+
+# ---
+
+- name: "4.3.3 | Ensure sudo log file exists"
+  when: "'4.3.3' not in active_exceptions"
+  tags: [rule_4.3.3, level1, section_4, manual]
+  block:
+
+    - name: "4.3.3 | AUDIT | Check Defaults logfile in sudoers"
+      ansible.builtin.command: >-
+        grep -Ei '^[[:space:]]*Defaults[[:space:]]+([^#,]+,)?logfile[[:space:]]*='
+        /usr/local/etc/sudoers
+      register: cis_4_3_3_logfile
+      changed_when: cis_4_3_3_logfile.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.3 | AUDIT | Report sudo logfile state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: Defaults logfile is configured — ' ~ cis_4_3_3_logfile.stdout | trim
+             if cis_4_3_3_logfile.stdout != ''
+             else 'NON-COMPLIANT: Defaults logfile is not configured in sudoers' }}
+
+    - name: "4.3.3 | REMEDIATE | Add Defaults logfile to sudoers"
+      ansible.builtin.lineinfile:
+        path: /usr/local/etc/sudoers
+        regexp: '^\s*Defaults\s+logfile='
+        line: 'Defaults logfile="{{ freebsd_cis_sudo_logfile }}"'
+        validate: 'visudo -cf %s'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_3_3_logfile.stdout == ''
+
+# ---
+
+- name: "4.3.4 | Ensure users must provide password for escalation"
+  when:
+    - "'4.3.4' not in active_exceptions"
+    - freebsd_cis_level | int >= 2
+  tags: [rule_4.3.4, level2, section_4, manual]
+  block:
+
+    - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
+      ansible.builtin.command: grep -r '^[^#].*NOPASSWD' /usr/local/etc/sudoers
+      register: cis_4_3_4_nopasswd
+      changed_when: cis_4_3_4_nopasswd.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.4 | AUDIT | Report NOPASSWD state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['NON-COMPLIANT: NOPASSWD entries found — review and remove:']
+             + cis_4_3_4_nopasswd.stdout_lines
+             if cis_4_3_4_nopasswd.stdout != ''
+             else 'COMPLIANT: no NOPASSWD entries found in sudoers' }}
+
+# ---
+
+- name: "4.3.5 | Ensure re-authentication for privilege escalation is not disabled globally"
+  when: "'4.3.5' not in active_exceptions"
+  tags: [rule_4.3.5, level1, section_4, manual]
+  block:
+
+    - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"
+      ansible.builtin.command: grep -r '^[^#].*!authenticate' /usr/local/etc/sudoers
+      register: cis_4_3_5_noauth
+      changed_when: cis_4_3_5_noauth.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.5 | AUDIT | Report !authenticate state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['NON-COMPLIANT: !authenticate entries found — review and remove:']
+             + cis_4_3_5_noauth.stdout_lines
+             if cis_4_3_5_noauth.stdout != ''
+             else 'COMPLIANT: no !authenticate entries found in sudoers' }}
+
+# ---
+
+- name: "4.3.6 | Ensure sudo authentication timeout is configured correctly"
+  when: "'4.3.6' not in active_exceptions"
+  tags: [rule_4.3.6, level1, section_4, manual]
+  block:
+
+    - name: "4.3.6 | AUDIT | Get timestamp_timeout from sudoers"
+      ansible.builtin.command: grep -E 'timestamp_timeout=-?[0-9]+' /usr/local/etc/sudoers
+      register: cis_4_3_6_timeout_raw
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.6 | AUDIT | Evaluate timestamp_timeout compliance"
+      ansible.builtin.set_fact:
+        cis_4_3_6_timeout_val: >-
+          {{ (cis_4_3_6_timeout_raw.stdout
+              | regex_search('timestamp_timeout=(-?[0-9]+)', '\1')
+              | first | int)
+             if cis_4_3_6_timeout_raw.stdout != ''
+             else 5 }}
+      changed_when: >-
+        cis_4_3_6_timeout_val | int == -1 or
+        cis_4_3_6_timeout_val | int > freebsd_cis_sudo_timeout | int
+      check_mode: false
+
+    - name: "4.3.6 | AUDIT | Report timestamp_timeout state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: sudo timestamp_timeout=' ~ cis_4_3_6_timeout_val ~ ' minutes'
+             if not (cis_4_3_6_timeout_val | int == -1 or
+                     cis_4_3_6_timeout_val | int > freebsd_cis_sudo_timeout | int)
+             else 'NON-COMPLIANT: sudo timestamp_timeout=' ~ cis_4_3_6_timeout_val ~
+                  ' — must be 1–' ~ freebsd_cis_sudo_timeout ~
+                  ' (not -1 or > ' ~ freebsd_cis_sudo_timeout ~ ')' }}
+
+    - name: "4.3.6 | REMEDIATE | Set timestamp_timeout in sudoers"
+      ansible.builtin.lineinfile:
+        path: /usr/local/etc/sudoers
+        regexp: '^\s*Defaults\s+.*timestamp_timeout='
+        line: 'Defaults timestamp_timeout={{ freebsd_cis_sudo_timeout }}'
+        validate: 'visudo -cf %s'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_3_6_timeout_val | int == -1 or
+          cis_4_3_6_timeout_val | int > freebsd_cis_sudo_timeout | int
+
+# ---
+
+- name: "4.3.7 | Ensure access to the su command is restricted"
+  when: "'4.3.7' not in active_exceptions"
+  tags: [rule_4.3.7, level1, section_4, manual]
+  block:
+
+    - name: "4.3.7 | AUDIT | Check pam_group.so restriction on su"
+      ansible.builtin.command: >-
+        grep -Ei '^auth[[:space:]]+(required|requisite)[[:space:]]+pam_group[.]so'
+        /etc/pam.d/su
+      register: cis_4_3_7_pam_su
+      changed_when: cis_4_3_7_pam_su.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.3.7 | AUDIT | Report su restriction state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['4.3.7 su restriction audit:',
+              ('  pam_group.so: COMPLIANT — su is restricted via pam_group.so'
+               if cis_4_3_7_pam_su.stdout != ''
+               else '  pam_group.so: NON-COMPLIANT — pam_group.so not configured in /etc/pam.d/su'),
+              '  NOTE: manually verify the configured group contains no members'] }}
+
+# =============================================================
+# 4.4 Configure Pluggable Authentication Modules
+# =============================================================
+
+# ---
+
+- name: "4.4.1.1.1 | Ensure password length is configured"
+  when: "'4.4.1.1.1' not in active_exceptions"
+  tags: [rule_4.4.1.1.1, level1, section_4, manual]
+  block:
+
+    - name: "4.4.1.1.1 | AUDIT | Check pam_passwdqc minlen in /etc/pam.d/passwd"
+      ansible.builtin.command: grep -Ei 'pam_passwdqc[.]so.*minlen=' /etc/pam.d/passwd
+      register: cis_4_4_1_1_1_minlen
+      changed_when: cis_4_4_1_1_1_minlen.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.4.1.1.1 | AUDIT | Report pam_passwdqc minlen state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: pam_passwdqc minlen configured — ' ~ cis_4_4_1_1_1_minlen.stdout | trim
+             if cis_4_4_1_1_1_minlen.stdout != ''
+             else 'NON-COMPLIANT: pam_passwdqc minlen not found in /etc/pam.d/passwd' }}
+
+    - name: "4.4.1.1.1 | REMEDIATE | Configure pam_passwdqc minlen in /etc/pam.d/passwd"
+      ansible.builtin.lineinfile:
+        path: /etc/pam.d/passwd
+        regexp: '^\s*password\s+(requisite|required)\s+pam_passwdqc\.so'
+        line: "password  requisite  pam_passwdqc.so  enforce=everyone minlen={{ freebsd_cis_pam_passwdqc_minlen }}"
+        create: true
+        owner: root
+        group: wheel
+        mode: '0644'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_4_1_1_1_minlen.stdout == ''
+
+# ---
+
+- name: "4.4.1.1.2 | Ensure password quality is enforced for the root user"
+  when: "'4.4.1.1.2' not in active_exceptions"
+  tags: [rule_4.4.1.1.2, level1, section_4, manual]
+  block:
+
+    - name: "4.4.1.1.2 | AUDIT | Check pam_passwdqc enforce=everyone in /etc/pam.d/passwd"
+      ansible.builtin.command: >-
+        grep -Ei 'pam_passwdqc[.]so.*\benforce=everyone\b' /etc/pam.d/passwd
+      register: cis_4_4_1_1_2_enforce
+      changed_when: cis_4_4_1_1_2_enforce.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.4.1.1.2 | AUDIT | Report enforce=everyone state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: pam_passwdqc enforce=everyone is configured'
+             if cis_4_4_1_1_2_enforce.stdout != ''
+             else 'NON-COMPLIANT: pam_passwdqc enforce=everyone not found in /etc/pam.d/passwd' }}
+
+    - name: "4.4.1.1.2 | REMEDIATE | Ensure enforce=everyone in pam_passwdqc line"
+      ansible.builtin.replace:
+        path: /etc/pam.d/passwd
+        regexp: '^(\s*password\s+(?:requisite|required)\s+pam_passwdqc\.so)(?!.*\benforce=everyone\b)(.*)'
+        replace: '\1 enforce=everyone\2'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_4_1_1_2_enforce.stdout == ''
+
+# ---
+
+- name: "4.4.1.2.1 | Ensure pam_unix does not include nullok"
+  when: "'4.4.1.2.1' not in active_exceptions"
+  tags: [rule_4.4.1.2.1, level1, section_4, manual]
+  block:
+
+    - name: "4.4.1.2.1 | AUDIT | Check for nullok in pam_unix.so lines"
+      ansible.builtin.command: >-
+        grep -E '^[[:space:]]*(auth|account|password|session)[[:space:]]+(requisite|required|sufficient)[[:space:]]+pam_unix[.]so\b.*\bnullok\b'
+        /etc/pam.d/passwd /etc/pam.d/system
+      register: cis_4_4_1_2_1_nullok
+      changed_when: cis_4_4_1_2_1_nullok.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.4.1.2.1 | AUDIT | Report nullok state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['NON-COMPLIANT: nullok found in pam_unix.so entries — review:']
+             + cis_4_4_1_2_1_nullok.stdout_lines
+             if cis_4_4_1_2_1_nullok.stdout != ''
+             else 'COMPLIANT: nullok not present in pam_unix.so entries' }}
+
+    - name: "4.4.1.2.1 | REMEDIATE | Remove nullok from pam_unix.so lines"
+      ansible.builtin.replace:
+        path: "{{ item }}"
+        regexp: '\s*\bnullok\b'
+        replace: ''
+      loop:
+        - /etc/pam.d/passwd
+        - /etc/pam.d/system
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_4_1_2_1_nullok.stdout != ''
+
+# =============================================================
+# 4.5 User Accounts and Environment
+# =============================================================
+
+# ---
+
+- name: "4.5.1.1 | Ensure strong password hashing algorithm is configured"
+  when: "'4.5.1.1' not in active_exceptions"
+  tags: [rule_4.5.1.1, level1, section_4, manual]
+  block:
+
+    - name: "4.5.1.1 | AUDIT | Check passwd_format in /etc/login.conf"
+      ansible.builtin.command: grep -E ':passwd_format=sha512:' /etc/login.conf
+      register: cis_4_5_1_1_hash
+      changed_when: cis_4_5_1_1_hash.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.1.1 | AUDIT | Report password hashing state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: passwd_format=sha512 is set in /etc/login.conf'
+             if cis_4_5_1_1_hash.stdout != ''
+             else 'NON-COMPLIANT: passwd_format=sha512 not found in /etc/login.conf' }}
+
+    - name: "4.5.1.1 | REMEDIATE | Set passwd_format=sha512 in /etc/login.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/login.conf
+        regexp: '^\s*:passwd_format='
+        line: ":passwd_format=sha512:\\"
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_1_hash.stdout == ''
+
+    - name: "4.5.1.1 | REMEDIATE | Regenerate login.conf.db"
+      ansible.builtin.command: cap_mkdb /etc/login.conf
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_1_hash.stdout == ''
+
+# ---
+
+- name: "4.5.1.2 | Ensure password expiration is 365 days or less"
+  when: "'4.5.1.2' not in active_exceptions"
+  tags: [rule_4.5.1.2, level1, section_4, automated]
+  block:
+
+    - name: "4.5.1.2 | AUDIT | Check passwordtime in /etc/login.conf"
+      ansible.builtin.command: grep -E '^[[:space:]]*:passwordtime=' /etc/login.conf
+      register: cis_4_5_1_2_pwexp
+      changed_when: cis_4_5_1_2_pwexp.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.1.2 | AUDIT | Report password expiration state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: passwordtime is configured — ' ~ cis_4_5_1_2_pwexp.stdout | trim
+             if cis_4_5_1_2_pwexp.stdout != ''
+             else 'NON-COMPLIANT: passwordtime not set in /etc/login.conf — password expiry is inactive' }}
+
+    - name: "4.5.1.2 | REMEDIATE | Set passwordtime in /etc/login.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/login.conf
+        regexp: '^\s*:passwordtime='
+        line: ":passwordtime={{ freebsd_cis_pw_max_age }}d:\\"
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_2_pwexp.stdout == ''
+
+    - name: "4.5.1.2 | REMEDIATE | Regenerate login.conf.db"
+      ansible.builtin.command: cap_mkdb /etc/login.conf
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_2_pwexp.stdout == ''
+
+    - name: "4.5.1.2 | REMEDIATE | Get list of regular users"
+      ansible.builtin.command: >-
+        awk -F: '($3>=1000)&&($1!="nobody"){print $1}' /etc/passwd
+      register: cis_4_5_1_2_users
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_2_pwexp.stdout == ''
+
+    - name: "4.5.1.2 | REMEDIATE | Set password expiry for regular users"
+      ansible.builtin.command: "pw usermod -n {{ item }} -p +{{ freebsd_cis_pw_max_age }}d"
+      loop: "{{ cis_4_5_1_2_users.stdout_lines | default([]) }}"
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_2_pwexp.stdout == ''
+        - cis_4_5_1_2_users is defined
+        - cis_4_5_1_2_users.stdout_lines | default([]) | length > 0
+
+# ---
+
+- name: "4.5.1.3 | Ensure password expiration warning days is 7 or more"
+  when: "'4.5.1.3' not in active_exceptions"
+  tags: [rule_4.5.1.3, level1, section_4, manual]
+  block:
+
+    - name: "4.5.1.3 | AUDIT | Check warnpassword in /etc/login.conf"
+      ansible.builtin.command: grep -E '^[[:space:]]*:warnpassword=' /etc/login.conf
+      register: cis_4_5_1_3_pwwarn
+      changed_when: cis_4_5_1_3_pwwarn.stdout == ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.1.3 | AUDIT | Report password warning state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: warnpassword is configured — ' ~ cis_4_5_1_3_pwwarn.stdout | trim
+             if cis_4_5_1_3_pwwarn.stdout != ''
+             else 'NON-COMPLIANT: warnpassword not set in /etc/login.conf — no expiration warnings issued' }}
+
+    - name: "4.5.1.3 | REMEDIATE | Set warnpassword in /etc/login.conf"
+      ansible.builtin.lineinfile:
+        path: /etc/login.conf
+        regexp: '^\s*:warnpassword='
+        line: ":warnpassword={{ freebsd_cis_pw_warn_days }}d:\\"
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_3_pwwarn.stdout == ''
+
+    - name: "4.5.1.3 | REMEDIATE | Regenerate login.conf.db"
+      ansible.builtin.command: cap_mkdb /etc/login.conf
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_1_3_pwwarn.stdout == ''
+
+# ---
+
+- name: "4.5.2.1 | Ensure default group for the root account is GID 0"
+  when: "'4.5.2.1' not in active_exceptions"
+  tags: [rule_4.5.2.1, level1, section_4, manual]
+  block:
+
+    - name: "4.5.2.1 | AUDIT | Check root GID in /etc/passwd"
+      ansible.builtin.command:
+        argv:
+          - awk
+          - '-F:'
+          - '$1=="root"{print $4}'
+          - /etc/passwd
+      register: cis_4_5_2_1_root_gid
+      changed_when: cis_4_5_2_1_root_gid.stdout | trim != '0'
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.2.1 | AUDIT | Report root GID state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: root primary GID is 0'
+             if cis_4_5_2_1_root_gid.stdout | trim == '0'
+             else 'NON-COMPLIANT: root primary GID is ' ~ cis_4_5_2_1_root_gid.stdout | trim ~ ' — expected 0' }}
+
+    - name: "4.5.2.1 | REMEDIATE | Set root primary GID to 0"
+      ansible.builtin.command: pw usermod -g 0 root
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_2_1_root_gid.stdout | trim != '0'
+
+# ---
+
+- name: "4.5.2.2 | Ensure root user umask is configured"
+  when: "'4.5.2.2' not in active_exceptions"
+  tags: [rule_4.5.2.2, level1, section_4, manual]
+  block:
+
+    - name: "4.5.2.2 | AUDIT | Check for umask settings in root shell config files"
+      ansible.builtin.command: >-
+        grep -Esi '^[[:space:]]*umask[[:space:]]' /root/.profile /root/.shrc
+      register: cis_4_5_2_2_umask
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.2.2 | AUDIT | Report root umask state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['4.5.2.2 root umask — verify value is 0027 or more restrictive:']
+             + (cis_4_5_2_2_umask.stdout_lines
+                if cis_4_5_2_2_umask.stdout != ''
+                else ['  No explicit umask found in /root/.profile or /root/.shrc — system default applies'])
+             + ['  CIS requirement: umask 0027 or more restrictive for root'] }}
+
+# ---
+
+- name: "4.5.2.3 | Ensure system accounts are secured"
+  when: "'4.5.2.3' not in active_exceptions"
+  tags: [rule_4.5.2.3, level1, section_4, manual]
+  block:
+
+    - name: "4.5.2.3 | AUDIT | Check system accounts with interactive shells"
+      ansible.builtin.command:
+        cmd: >-
+          awk -F: '($1!~/^(root|toor|uucp)$/ || $3 == 65533) &&
+          $7!~/^(\/usr)?\/sbin\/nologin$/ { print $1 }' /etc/passwd
+      register: cis_4_5_2_3_shell
+      changed_when: cis_4_5_2_3_shell.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.2.3 | AUDIT | Check nologin accounts with non-locked passwords"
+      ansible.builtin.command:
+        cmd: >-
+          awk -F: '($2!="*" && $7~/^(\/usr)?\/sbin\/nologin$/) { print $1 }'
+          /etc/master.passwd
+      register: cis_4_5_2_3_passwd
+      changed_when: cis_4_5_2_3_passwd.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.2.3 | AUDIT | Report system account state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['4.5.2.3 system accounts audit:',
+              ('  Shell check: COMPLIANT — all system accounts use nologin'
+               if cis_4_5_2_3_shell.stdout == ''
+               else '  Shell check: NON-COMPLIANT — accounts with interactive shells: '
+                    ~ cis_4_5_2_3_shell.stdout_lines | join(', ')),
+              ('  Password check: COMPLIANT — all nologin accounts have locked passwords'
+               if cis_4_5_2_3_passwd.stdout == ''
+               else '  Password check: NON-COMPLIANT — nologin accounts with non-locked passwords: '
+                    ~ cis_4_5_2_3_passwd.stdout_lines | join(', '))] }}
+
+    - name: "4.5.2.3 | REMEDIATE | Set nologin shell for system accounts"
+      ansible.builtin.command: "pw usermod -s /usr/sbin/nologin {{ item }}"
+      loop: "{{ cis_4_5_2_3_shell.stdout_lines }}"
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_2_3_shell.stdout != ''
+
+    - name: "4.5.2.3 | REMEDIATE | Lock passwords for nologin accounts"
+      ansible.builtin.command: "pw lock {{ item }}"
+      loop: "{{ cis_4_5_2_3_passwd.stdout_lines }}"
+      changed_when: true
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_2_3_passwd.stdout != ''
+
+# ---
+
+- name: "4.5.3.1 | Ensure nologin is not listed in /etc/shells"
+  when:
+    - "'4.5.3.1' not in active_exceptions"
+    - freebsd_cis_level | int >= 2
+  tags: [rule_4.5.3.1, level2, section_4, manual]
+  block:
+
+    - name: "4.5.3.1 | AUDIT | Check for nologin in /etc/shells"
+      ansible.builtin.command: grep '/nologin' /etc/shells
+      register: cis_4_5_3_1_nologin
+      changed_when: cis_4_5_3_1_nologin.stdout != ''
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.3.1 | AUDIT | Report /etc/shells nologin state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ ['NON-COMPLIANT: nologin found in /etc/shells — remove:']
+             + cis_4_5_3_1_nologin.stdout_lines
+             if cis_4_5_3_1_nologin.stdout != ''
+             else 'COMPLIANT: nologin is not listed in /etc/shells' }}
+
+    - name: "4.5.3.1 | REMEDIATE | Remove nologin entries from /etc/shells"
+      ansible.builtin.lineinfile:
+        path: /etc/shells
+        regexp: '/nologin\b'
+        state: absent
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_4_5_3_1_nologin.stdout != ''
+
+# ---
+
+- name: "4.5.3.2 | Ensure default user umask is configured"
+  when: "'4.5.3.2' not in active_exceptions"
+  tags: [rule_4.5.3.2, level1, section_4, manual]
+  block:
+
+    - name: "4.5.3.2 | AUDIT | Check umask in /etc/login.conf"
+      ansible.builtin.command: grep -Ei ':umask=0?22:' /etc/login.conf
+      register: cis_4_5_3_2_login_conf
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.3.2 | AUDIT | Check umask in /etc/profile and /etc/csh.cshrc"
+      ansible.builtin.command: >-
+        grep -Eri 'umask[[:space:]]+0?22\b' /etc/profile /etc/csh.cshrc
+      register: cis_4_5_3_2_profile
+      changed_when: false
+      failed_when: false
+      check_mode: false
+
+    - name: "4.5.3.2 | AUDIT | Evaluate default user umask compliance"
+      ansible.builtin.set_fact:
+        cis_4_5_3_2_compliant: >-
+          {{ cis_4_5_3_2_login_conf.stdout != '' or cis_4_5_3_2_profile.stdout != '' }}
+      changed_when: not cis_4_5_3_2_compliant | bool
+      check_mode: false
+
+    - name: "4.5.3.2 | AUDIT | Report default user umask state"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'COMPLIANT: default user umask 022 found in ' ~
+             ('/etc/login.conf'
+              if cis_4_5_3_2_login_conf.stdout != ''
+              else '/etc/profile or /etc/csh.cshrc')
+             if cis_4_5_3_2_compliant | bool
+             else 'NON-COMPLIANT: umask 022 not found in /etc/login.conf, /etc/profile, or /etc/csh.cshrc' }}

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -80,9 +80,9 @@
              (cis_4_1_1_2_crond.stat.pw_name | default('?')) ~ ' group=' ~
              (cis_4_1_1_2_crond.stat.gr_name | default('?')) ~ ' mode=' ~
              (cis_4_1_1_2_crond.stat.mode | default('?')) ~
-             ' — expected root:wheel with no group/other permissions'
+             ' — expected root:wheel mode 0700 (owner rwx, no group/other)'
              if cis_4_1_1_2_crond is changed
-             else 'COMPLIANT: /etc/cron.d is root:wheel with no group/other permissions' }}
+             else 'COMPLIANT: /etc/cron.d is root:wheel mode 0700' }}
 
     - name: "4.1.1.2 | REMEDIATE | Set /etc/cron.d owner, group, and mode"
       ansible.builtin.file:
@@ -415,7 +415,7 @@
              (item.stat.pw_name | default('?')) ~ ' group=' ~
              (item.stat.gr_name | default('?')) ~ ' mode=' ~
              (item.stat.mode | default('?')) ~
-             ' — expected root:wheel mode 0600'
+             ' — expected root:wheel mode 0600 or 0400'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
                  ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
@@ -1449,7 +1449,7 @@
   block:
 
     - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
-      ansible.builtin.command: grep -r '^[^#].*NOPASSWD' /usr/local/etc/sudoers
+      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*NOPASSWD' /usr/local/etc/sudoers
       register: cis_4_3_4_nopasswd
       changed_when: cis_4_3_4_nopasswd.rc != 1
       failed_when: false
@@ -1474,7 +1474,7 @@
   block:
 
     - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"
-      ansible.builtin.command: grep -r '^[^#].*!authenticate' /usr/local/etc/sudoers
+      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*!authenticate' /usr/local/etc/sudoers
       register: cis_4_3_5_noauth
       changed_when: cis_4_3_5_noauth.rc != 1
       failed_when: false
@@ -1499,7 +1499,7 @@
   block:
 
     - name: "4.3.6 | AUDIT | Get timestamp_timeout from sudoers"
-      ansible.builtin.command: grep -E 'timestamp_timeout=-?[0-9]+' /usr/local/etc/sudoers
+      ansible.builtin.command: grep -E '^[[:space:]]*Defaults[[:space:]].*timestamp_timeout=-?[0-9]+' /usr/local/etc/sudoers
       register: cis_4_3_6_timeout_raw
       changed_when: false
       failed_when: false

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1382,7 +1382,7 @@
 
     - name: "4.3.2 | AUDIT | Check Defaults use_pty in sudoers"
       ansible.builtin.command: >-
-        grep -Ei '^[[:space:]]*Defaults[[:space:]]+([^#,]+,[[:space:]]*)?use_pty'
+        grep -Ei '^[[:space:]]*Defaults[[:space:]].*use_pty([[:space:]]|,|$)'
         /usr/local/etc/sudoers
       register: cis_4_3_2_use_pty
       changed_when: cis_4_3_2_use_pty.stdout == ''
@@ -1399,7 +1399,7 @@
     - name: "4.3.2 | REMEDIATE | Add Defaults use_pty to sudoers"
       ansible.builtin.lineinfile:
         path: /usr/local/etc/sudoers
-        regexp: '^\s*Defaults\s+([^#,]+,\s*)?use_pty'
+        regexp: '^\s*Defaults\s+.*use_pty(\s|,|$)'
         line: 'Defaults use_pty'
         validate: 'visudo -cf %s'
       when:
@@ -1415,7 +1415,7 @@
 
     - name: "4.3.3 | AUDIT | Check Defaults logfile in sudoers"
       ansible.builtin.command: >-
-        grep -Ei '^[[:space:]]*Defaults[[:space:]]+([^#,]+,)?logfile[[:space:]]*='
+        grep -Ei '^[[:space:]]*Defaults[[:space:]].*logfile[[:space:]]*='
         /usr/local/etc/sudoers
       register: cis_4_3_3_logfile
       changed_when: cis_4_3_3_logfile.stdout == ''
@@ -1432,7 +1432,7 @@
     - name: "4.3.3 | REMEDIATE | Add Defaults logfile to sudoers"
       ansible.builtin.lineinfile:
         path: /usr/local/etc/sudoers
-        regexp: '^\s*Defaults\s+([^#,]+,\s*)?logfile='
+        regexp: '^\s*Defaults\s+.*logfile\s*='
         line: 'Defaults logfile="{{ freebsd_cis_sudo_logfile }}"'
         validate: 'visudo -cf %s'
       when:
@@ -1448,22 +1448,47 @@
   tags: [rule_4.3.4, level2, section_4, manual]
   block:
 
+    - name: "4.3.4 | AUDIT | Stat sudoers.d include directory"
+      ansible.builtin.stat:
+        path: /usr/local/etc/sudoers.d
+      register: cis_4_3_4_sudoers_d
+      changed_when: false
+      check_mode: false
+
     - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
-      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*NOPASSWD' /usr/local/etc/sudoers
+      ansible.builtin.command: grep -E '^[[:space:]]*[^#[:space:]].*NOPASSWD' /usr/local/etc/sudoers
       register: cis_4_3_4_nopasswd
-      changed_when: cis_4_3_4_nopasswd.rc != 1
+      changed_when: false
       failed_when: false
+      check_mode: false
+
+    - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers.d"
+      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*NOPASSWD' /usr/local/etc/sudoers.d
+      register: cis_4_3_4_nopasswd_d
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      when: cis_4_3_4_sudoers_d.stat.exists
+
+    - name: "4.3.4 | AUDIT | Summarize NOPASSWD state"
+      ansible.builtin.set_fact:
+        cis_4_3_4_nopasswd_lines: >-
+          {{ (cis_4_3_4_nopasswd.stdout_lines | default([])) +
+             (cis_4_3_4_nopasswd_d.stdout_lines | default([])) }}
+        cis_4_3_4_nopasswd_error: >-
+          {{ (cis_4_3_4_nopasswd.rc not in [0, 1]) or
+             (cis_4_3_4_sudoers_d.stat.exists and cis_4_3_4_nopasswd_d.rc not in [0, 1]) }}
+      changed_when: (cis_4_3_4_nopasswd_error | bool) or (cis_4_3_4_nopasswd_lines | length > 0)
       check_mode: false
 
     - name: "4.3.4 | AUDIT | Report NOPASSWD state"
       ansible.builtin.debug:
         msg: >-
           {{ ['NON-COMPLIANT: NOPASSWD entries found — review and remove:']
-             + cis_4_3_4_nopasswd.stdout_lines
-             if cis_4_3_4_nopasswd.rc == 0
-             else ('NON-COMPLIANT: grep error (rc=' ~ cis_4_3_4_nopasswd.rc ~
-                   ') — sudoers missing or unreadable'
-                   if cis_4_3_4_nopasswd.rc != 1
+             + cis_4_3_4_nopasswd_lines
+             if (cis_4_3_4_nopasswd_lines | length > 0)
+             else ('NON-COMPLIANT: grep error while reading sudoers content'
+                   if cis_4_3_4_nopasswd_error | bool
                    else 'COMPLIANT: no NOPASSWD entries found in sudoers') }}
 
 # ---
@@ -1473,22 +1498,47 @@
   tags: [rule_4.3.5, level1, section_4, manual]
   block:
 
+    - name: "4.3.5 | AUDIT | Stat sudoers.d include directory"
+      ansible.builtin.stat:
+        path: /usr/local/etc/sudoers.d
+      register: cis_4_3_5_sudoers_d
+      changed_when: false
+      check_mode: false
+
     - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"
-      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*!authenticate' /usr/local/etc/sudoers
+      ansible.builtin.command: grep -E '^[[:space:]]*[^#[:space:]].*!authenticate' /usr/local/etc/sudoers
       register: cis_4_3_5_noauth
-      changed_when: cis_4_3_5_noauth.rc != 1
+      changed_when: false
       failed_when: false
+      check_mode: false
+
+    - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers.d"
+      ansible.builtin.command: grep -rE '^[[:space:]]*[^#[:space:]].*!authenticate' /usr/local/etc/sudoers.d
+      register: cis_4_3_5_noauth_d
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      when: cis_4_3_5_sudoers_d.stat.exists
+
+    - name: "4.3.5 | AUDIT | Summarize !authenticate state"
+      ansible.builtin.set_fact:
+        cis_4_3_5_noauth_lines: >-
+          {{ (cis_4_3_5_noauth.stdout_lines | default([])) +
+             (cis_4_3_5_noauth_d.stdout_lines | default([])) }}
+        cis_4_3_5_noauth_error: >-
+          {{ (cis_4_3_5_noauth.rc not in [0, 1]) or
+             (cis_4_3_5_sudoers_d.stat.exists and cis_4_3_5_noauth_d.rc not in [0, 1]) }}
+      changed_when: (cis_4_3_5_noauth_error | bool) or (cis_4_3_5_noauth_lines | length > 0)
       check_mode: false
 
     - name: "4.3.5 | AUDIT | Report !authenticate state"
       ansible.builtin.debug:
         msg: >-
           {{ ['NON-COMPLIANT: !authenticate entries found — review and remove:']
-             + cis_4_3_5_noauth.stdout_lines
-             if cis_4_3_5_noauth.rc == 0
-             else ('NON-COMPLIANT: grep error (rc=' ~ cis_4_3_5_noauth.rc ~
-                   ') — sudoers missing or unreadable'
-                   if cis_4_3_5_noauth.rc != 1
+             + cis_4_3_5_noauth_lines
+             if (cis_4_3_5_noauth_lines | length > 0)
+             else ('NON-COMPLIANT: grep error while reading sudoers content'
+                   if cis_4_3_5_noauth_error | bool
                    else 'COMPLIANT: no !authenticate entries found in sudoers') }}
 
 # ---
@@ -1524,9 +1574,8 @@
           {{ 'COMPLIANT: sudo timestamp_timeout=' ~ cis_4_3_6_timeout_val ~ ' minutes'
              if not (cis_4_3_6_timeout_val | int == -1 or
                      cis_4_3_6_timeout_val | int > freebsd_cis_sudo_timeout | int)
-             else 'NON-COMPLIANT: sudo timestamp_timeout=' ~ cis_4_3_6_timeout_val ~
-                  ' — must be 1–' ~ freebsd_cis_sudo_timeout ~
-                  ' (not -1 or > ' ~ freebsd_cis_sudo_timeout ~ ')' }}
+               else 'NON-COMPLIANT: sudo timestamp_timeout=' ~ cis_4_3_6_timeout_val ~
+                 ' — must not be -1 and must be <= ' ~ freebsd_cis_sudo_timeout }}
 
     - name: "4.3.6 | REMEDIATE | Set timestamp_timeout in sudoers"
       ansible.builtin.lineinfile:
@@ -1612,7 +1661,7 @@
         path: /etc/pam.d/passwd
         regexp: '^\s*password\s+(requisite|required)\s+pam_passwdqc\.so'
         line: "password  requisite  pam_passwdqc.so  enforce=everyone minlen={{ freebsd_cis_pam_passwdqc_minlen }}"
-        create: true
+        create: false
         owner: root
         group: wheel
         mode: '0644'
@@ -1720,6 +1769,8 @@
       ansible.builtin.lineinfile:
         path: /etc/login.conf
         regexp: '^\s*:passwd_format='
+        insertafter: '^default:\\$'
+        firstmatch: true
         line: ":passwd_format=sha512:\\"
       when:
         - freebsd_cis_remediate | bool
@@ -1779,6 +1830,8 @@
       ansible.builtin.lineinfile:
         path: /etc/login.conf
         regexp: '^\s*:passwordtime='
+        insertafter: '^default:\\$'
+        firstmatch: true
         line: ":passwordtime={{ freebsd_cis_pw_max_age }}d:\\"
       when:
         - freebsd_cis_remediate | bool
@@ -1881,6 +1934,8 @@
       ansible.builtin.lineinfile:
         path: /etc/login.conf
         regexp: '^\s*:warnpassword='
+        insertafter: '^default:\\$'
+        firstmatch: true
         line: ":warnpassword={{ freebsd_cis_pw_warn_days }}d:\\"
       when:
         - freebsd_cis_remediate | bool

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -258,16 +258,38 @@
 # =============================================================
 
 - name: "4.2 | GATHER | Query sshd effective configuration via sshd -T"
+  when: >-
+    ('4.2.4' not in active_exceptions) or
+    ('4.2.5' not in active_exceptions) or
+    ('4.2.6' not in active_exceptions) or
+    ('4.2.7' not in active_exceptions) or
+    ('4.2.8' not in active_exceptions) or
+    ('4.2.9' not in active_exceptions) or
+    ('4.2.10' not in active_exceptions) or
+    ('4.2.11' not in active_exceptions) or
+    ('4.2.12' not in active_exceptions) or
+    ('4.2.13' not in active_exceptions) or
+    ('4.2.14' not in active_exceptions) or
+    ('4.2.15' not in active_exceptions) or
+    ('4.2.16' not in active_exceptions) or
+    ('4.2.17' not in active_exceptions) or
+    ('4.2.18' not in active_exceptions) or
+    ('4.2.19' not in active_exceptions) or
+    ('4.2.20' not in active_exceptions) or
+    ('4.2.21' not in active_exceptions)
+  tags: [section_4]
   ansible.builtin.command:
     argv:
       - "{{ freebsd_cis_sshd_bin }}"
       - -T
+      - -f
+      - "{{ freebsd_cis_sshd_config }}"
       - -C
       - "user=root"
       - -C
       - "host={{ ansible_facts['hostname'] }}"
       - -C
-      - "addr={{ ansible_facts['default_ipv4']['address'] | default('127.0.0.1') }}"
+      - "addr={{ (ansible_facts['default_ipv4'] | default({'address': '127.0.0.1'}))['address'] }}"
   register: cis_4_2_sshd_config_dump
   changed_when: false
   failed_when: false
@@ -338,6 +360,7 @@
         patterns: "ssh_host_*_key"
         file_type: file
       register: cis_4_2_2_privkeys
+      failed_when: false
       check_mode: false
 
     - name: "4.2.2 | AUDIT | Check private key permissions"
@@ -359,6 +382,7 @@
              ' — expected root:wheel mode 0600'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
+                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
                  (item.stat.mode | int(base=8)) % 64 != 0)
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
       loop: "{{ cis_4_2_2_privkey_stats.results }}"
@@ -373,7 +397,7 @@
              or (cis_4_2_2_privkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_2_privkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[0-7]00$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[46]00$') | list | length > 0) }}
       changed_when: cis_4_2_2_non_compliant | bool
       check_mode: false
 
@@ -405,6 +429,7 @@
         patterns: "ssh_host_*_key.pub"
         file_type: file
       register: cis_4_2_3_pubkeys
+      failed_when: false
       check_mode: false
 
     - name: "4.2.3 | AUDIT | Check public key permissions"
@@ -426,6 +451,7 @@
              ' — expected root:wheel mode 0644'
              if (item.stat.pw_name != 'root' or
                  item.stat.gr_name != 'wheel' or
+                 ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
                  (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
                  ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4])
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
@@ -441,7 +467,7 @@
              or (cis_4_2_3_pubkey_stats.results
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
              or (cis_4_2_3_pubkey_stats.results
-              | rejectattr('stat.mode', 'match', '^0[0-7][04][04]$') | list | length > 0) }}
+              | rejectattr('stat.mode', 'match', '^0[46][04][04]$') | list | length > 0) }}
       changed_when: cis_4_2_3_non_compliant | bool
       check_mode: false
 
@@ -492,6 +518,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -505,6 +533,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -518,6 +548,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -531,6 +563,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -569,6 +603,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -589,6 +625,7 @@
              | list | first | default('ciphers')
              | regex_replace('^ciphers\s+', '') | trim).split(',')
              | map('trim') | list }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.6 | AUDIT | Check for weak ciphers"
@@ -614,6 +651,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -660,6 +699,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -673,6 +714,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -710,6 +753,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -747,6 +792,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -784,6 +831,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -829,6 +878,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -867,6 +918,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -904,6 +957,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -949,6 +1004,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -986,6 +1043,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1023,6 +1082,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1042,12 +1103,13 @@
              | select('match', '^maxstartups\s')
              | list | first | default('maxstartups 10:30:100')
              | regex_replace('^maxstartups\s+', '') | trim }}
+      changed_when: false
       check_mode: false
 
     - name: "4.2.17 | AUDIT | Parse MaxStartups components"
       ansible.builtin.set_fact:
         cis_4_2_17_start: "{{ cis_4_2_17_val.split(':')[0] | int }}"
-        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 100 }}"
+        cis_4_2_17_rate: "{{ cis_4_2_17_val.split(':')[1] | int if ':' in cis_4_2_17_val else 0 }}"
         cis_4_2_17_full: "{{ cis_4_2_17_val.split(':')[2] | int if cis_4_2_17_val.split(':') | length > 2 else 100 }}"
       changed_when: >-
         (cis_4_2_17_start | int) > 10 or
@@ -1073,6 +1135,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1112,6 +1176,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1149,6 +1215,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1186,6 +1254,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1223,6 +1293,8 @@
         owner: root
         group: wheel
         mode: '0600'
+        insertbefore: '^\s*Match\b'
+        firstmatch: true
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
@@ -1287,7 +1359,7 @@
     - name: "4.3.2 | REMEDIATE | Add Defaults use_pty to sudoers"
       ansible.builtin.lineinfile:
         path: /usr/local/etc/sudoers
-        regexp: '^\s*Defaults\s+use_pty'
+        regexp: '^\s*Defaults\s+([^#,]+,\s*)?use_pty'
         line: 'Defaults use_pty'
         validate: 'visudo -cf %s'
       when:
@@ -1320,7 +1392,7 @@
     - name: "4.3.3 | REMEDIATE | Add Defaults logfile to sudoers"
       ansible.builtin.lineinfile:
         path: /usr/local/etc/sudoers
-        regexp: '^\s*Defaults\s+logfile='
+        regexp: '^\s*Defaults\s+([^#,]+,\s*)?logfile='
         line: 'Defaults logfile="{{ freebsd_cis_sudo_logfile }}"'
         validate: 'visudo -cf %s'
       when:
@@ -1339,7 +1411,7 @@
     - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
       ansible.builtin.command: grep -r '^[^#].*NOPASSWD' /usr/local/etc/sudoers
       register: cis_4_3_4_nopasswd
-      changed_when: cis_4_3_4_nopasswd.stdout != ''
+      changed_when: cis_4_3_4_nopasswd.rc == 0
       failed_when: false
       check_mode: false
 
@@ -1348,7 +1420,7 @@
         msg: >-
           {{ ['NON-COMPLIANT: NOPASSWD entries found — review and remove:']
              + cis_4_3_4_nopasswd.stdout_lines
-             if cis_4_3_4_nopasswd.stdout != ''
+             if cis_4_3_4_nopasswd.rc == 0
              else 'COMPLIANT: no NOPASSWD entries found in sudoers' }}
 
 # ---
@@ -1361,7 +1433,7 @@
     - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"
       ansible.builtin.command: grep -r '^[^#].*!authenticate' /usr/local/etc/sudoers
       register: cis_4_3_5_noauth
-      changed_when: cis_4_3_5_noauth.stdout != ''
+      changed_when: cis_4_3_5_noauth.rc == 0
       failed_when: false
       check_mode: false
 
@@ -1370,7 +1442,7 @@
         msg: >-
           {{ ['NON-COMPLIANT: !authenticate entries found — review and remove:']
              + cis_4_3_5_noauth.stdout_lines
-             if cis_4_3_5_noauth.stdout != ''
+             if cis_4_3_5_noauth.rc == 0
              else 'COMPLIANT: no !authenticate entries found in sudoers' }}
 
 # ---
@@ -1460,16 +1532,34 @@
     - name: "4.4.1.1.1 | AUDIT | Check pam_passwdqc minlen in /etc/pam.d/passwd"
       ansible.builtin.command: grep -Ei 'pam_passwdqc[.]so.*minlen=' /etc/pam.d/passwd
       register: cis_4_4_1_1_1_minlen
-      changed_when: cis_4_4_1_1_1_minlen.stdout == ''
+      changed_when: >-
+        cis_4_4_1_1_1_minlen.rc != 0 or
+        ((cis_4_4_1_1_1_minlen.stdout
+          | regex_search('minlen=(\S+)', '\1')
+          | default(['']) | first)
+         != (freebsd_cis_pam_passwdqc_minlen | string))
       failed_when: false
       check_mode: false
 
     - name: "4.4.1.1.1 | AUDIT | Report pam_passwdqc minlen state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'COMPLIANT: pam_passwdqc minlen configured — ' ~ cis_4_4_1_1_1_minlen.stdout | trim
-             if cis_4_4_1_1_1_minlen.stdout != ''
-             else 'NON-COMPLIANT: pam_passwdqc minlen not found in /etc/pam.d/passwd' }}
+          {{ 'NON-COMPLIANT: pam_passwdqc minlen not found in /etc/pam.d/passwd'
+             if cis_4_4_1_1_1_minlen.rc != 0
+             else ('COMPLIANT: pam_passwdqc minlen=' ~
+                   (cis_4_4_1_1_1_minlen.stdout
+                    | regex_search('minlen=(\S+)', '\1')
+                    | default(['']) | first) ~
+                   ' is configured'
+                   if (cis_4_4_1_1_1_minlen.stdout
+                       | regex_search('minlen=(\S+)', '\1')
+                       | default(['']) | first)
+                      == (freebsd_cis_pam_passwdqc_minlen | string)
+                   else 'NON-COMPLIANT: pam_passwdqc minlen=' ~
+                        (cis_4_4_1_1_1_minlen.stdout
+                         | regex_search('minlen=(\S+)', '\1')
+                         | default(['']) | first) ~
+                        ' — expected ' ~ freebsd_cis_pam_passwdqc_minlen) }}
 
     - name: "4.4.1.1.1 | REMEDIATE | Configure pam_passwdqc minlen in /etc/pam.d/passwd"
       ansible.builtin.lineinfile:
@@ -1482,7 +1572,11 @@
         mode: '0644'
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_4_1_1_1_minlen.stdout == ''
+        - cis_4_4_1_1_1_minlen.rc != 0 or
+          ((cis_4_4_1_1_1_minlen.stdout
+            | regex_search('minlen=(\S+)', '\1')
+            | default(['']) | first)
+           != (freebsd_cis_pam_passwdqc_minlen | string))
 
 # ---
 
@@ -1602,16 +1696,38 @@
     - name: "4.5.1.2 | AUDIT | Check passwordtime in /etc/login.conf"
       ansible.builtin.command: grep -E '^[[:space:]]*:passwordtime=' /etc/login.conf
       register: cis_4_5_1_2_pwexp
-      changed_when: cis_4_5_1_2_pwexp.stdout == ''
+      changed_when: >-
+        cis_4_5_1_2_pwexp.rc != 0 or
+        ((cis_4_5_1_2_pwexp.stdout
+          | regex_search(':passwordtime=(\d+)', '\1')
+          | default(['0']) | first | int) == 0) or
+        ((cis_4_5_1_2_pwexp.stdout
+          | regex_search(':passwordtime=(\d+)', '\1')
+          | default(['0']) | first | int)
+         > (freebsd_cis_pw_max_age | int))
       failed_when: false
       check_mode: false
 
     - name: "4.5.1.2 | AUDIT | Report password expiration state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'COMPLIANT: passwordtime is configured — ' ~ cis_4_5_1_2_pwexp.stdout | trim
-             if cis_4_5_1_2_pwexp.stdout != ''
-             else 'NON-COMPLIANT: passwordtime not set in /etc/login.conf — password expiry is inactive' }}
+          {{ 'NON-COMPLIANT: passwordtime not set in /etc/login.conf — password expiry is inactive'
+             if cis_4_5_1_2_pwexp.rc != 0
+             else ('COMPLIANT: passwordtime=' ~
+                   (cis_4_5_1_2_pwexp.stdout
+                    | regex_search(':passwordtime=(\d+)', '\1')
+                    | default(['0']) | first) ~ 'd'
+                   if (cis_4_5_1_2_pwexp.stdout
+                       | regex_search(':passwordtime=(\d+)', '\1')
+                       | default(['0']) | first | int) > 0 and
+                      (cis_4_5_1_2_pwexp.stdout
+                       | regex_search(':passwordtime=(\d+)', '\1')
+                       | default(['0']) | first | int) <= (freebsd_cis_pw_max_age | int)
+                   else 'NON-COMPLIANT: passwordtime=' ~
+                        (cis_4_5_1_2_pwexp.stdout
+                         | regex_search(':passwordtime=(\d+)', '\1')
+                         | default(['0']) | first) ~
+                        'd — expected 1–' ~ freebsd_cis_pw_max_age ~ 'd') }}
 
     - name: "4.5.1.2 | REMEDIATE | Set passwordtime in /etc/login.conf"
       ansible.builtin.lineinfile:
@@ -1620,14 +1736,28 @@
         line: ":passwordtime={{ freebsd_cis_pw_max_age }}d:\\"
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_2_pwexp.stdout == ''
+        - cis_4_5_1_2_pwexp.rc != 0 or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int) == 0) or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int)
+           > (freebsd_cis_pw_max_age | int))
 
     - name: "4.5.1.2 | REMEDIATE | Regenerate login.conf.db"
       ansible.builtin.command: cap_mkdb /etc/login.conf
       changed_when: true
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_2_pwexp.stdout == ''
+        - cis_4_5_1_2_pwexp.rc != 0 or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int) == 0) or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int)
+           > (freebsd_cis_pw_max_age | int))
 
     - name: "4.5.1.2 | REMEDIATE | Get list of regular users"
       ansible.builtin.command: >-
@@ -1638,7 +1768,14 @@
       check_mode: false
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_2_pwexp.stdout == ''
+        - cis_4_5_1_2_pwexp.rc != 0 or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int) == 0) or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int)
+           > (freebsd_cis_pw_max_age | int))
 
     - name: "4.5.1.2 | REMEDIATE | Set password expiry for regular users"
       ansible.builtin.command: "pw usermod -n {{ item }} -p +{{ freebsd_cis_pw_max_age }}d"
@@ -1646,7 +1783,14 @@
       changed_when: true
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_2_pwexp.stdout == ''
+        - cis_4_5_1_2_pwexp.rc != 0 or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int) == 0) or
+          ((cis_4_5_1_2_pwexp.stdout
+            | regex_search(':passwordtime=(\d+)', '\1')
+            | default(['0']) | first | int)
+           > (freebsd_cis_pw_max_age | int))
         - cis_4_5_1_2_users is defined
         - cis_4_5_1_2_users.stdout_lines | default([]) | length > 0
 
@@ -1660,16 +1804,32 @@
     - name: "4.5.1.3 | AUDIT | Check warnpassword in /etc/login.conf"
       ansible.builtin.command: grep -E '^[[:space:]]*:warnpassword=' /etc/login.conf
       register: cis_4_5_1_3_pwwarn
-      changed_when: cis_4_5_1_3_pwwarn.stdout == ''
+      changed_when: >-
+        cis_4_5_1_3_pwwarn.rc != 0 or
+        ((cis_4_5_1_3_pwwarn.stdout
+          | regex_search(':warnpassword=(\d+)', '\1')
+          | default(['0']) | first | int)
+         < (freebsd_cis_pw_warn_days | int))
       failed_when: false
       check_mode: false
 
     - name: "4.5.1.3 | AUDIT | Report password warning state"
       ansible.builtin.debug:
         msg: >-
-          {{ 'COMPLIANT: warnpassword is configured — ' ~ cis_4_5_1_3_pwwarn.stdout | trim
-             if cis_4_5_1_3_pwwarn.stdout != ''
-             else 'NON-COMPLIANT: warnpassword not set in /etc/login.conf — no expiration warnings issued' }}
+          {{ 'NON-COMPLIANT: warnpassword not set in /etc/login.conf — no expiration warnings issued'
+             if cis_4_5_1_3_pwwarn.rc != 0
+             else ('COMPLIANT: warnpassword=' ~
+                   (cis_4_5_1_3_pwwarn.stdout
+                    | regex_search(':warnpassword=(\d+)', '\1')
+                    | default(['0']) | first) ~ 'd'
+                   if (cis_4_5_1_3_pwwarn.stdout
+                       | regex_search(':warnpassword=(\d+)', '\1')
+                       | default(['0']) | first | int) >= (freebsd_cis_pw_warn_days | int)
+                   else 'NON-COMPLIANT: warnpassword=' ~
+                        (cis_4_5_1_3_pwwarn.stdout
+                         | regex_search(':warnpassword=(\d+)', '\1')
+                         | default(['0']) | first) ~
+                        'd — expected >= ' ~ freebsd_cis_pw_warn_days ~ 'd') }}
 
     - name: "4.5.1.3 | REMEDIATE | Set warnpassword in /etc/login.conf"
       ansible.builtin.lineinfile:
@@ -1678,14 +1838,22 @@
         line: ":warnpassword={{ freebsd_cis_pw_warn_days }}d:\\"
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_3_pwwarn.stdout == ''
+        - cis_4_5_1_3_pwwarn.rc != 0 or
+          ((cis_4_5_1_3_pwwarn.stdout
+            | regex_search(':warnpassword=(\d+)', '\1')
+            | default(['0']) | first | int)
+           < (freebsd_cis_pw_warn_days | int))
 
     - name: "4.5.1.3 | REMEDIATE | Regenerate login.conf.db"
       ansible.builtin.command: cap_mkdb /etc/login.conf
       changed_when: true
       when:
         - freebsd_cis_remediate | bool
-        - cis_4_5_1_3_pwwarn.stdout == ''
+        - cis_4_5_1_3_pwwarn.rc != 0 or
+          ((cis_4_5_1_3_pwwarn.stdout
+            | regex_search(':warnpassword=(\d+)', '\1')
+            | default(['0']) | first | int)
+           < (freebsd_cis_pw_warn_days | int))
 
 # ---
 


### PR DESCRIPTION
## Summary

Implements 18 CIS FreeBSD 14 Benchmark v1.0.1 controls for Section 4 Part B, covering sudo/privilege escalation (4.3), PAM (4.4), and user accounts/environment (4.5).

## Why

Completes the Section 4 coverage started in Part A (4.1–4.2). These controls govern how users escalate privileges and how passwords/accounts are secured — high-value hardening targets.

## Controls added

**4.3 — sudo / privilege escalation**
| ID | Title | Level | Type |
|----|-------|-------|------|
| 4.3.1 | sudo is installed | 1 | manual |
| 4.3.2 | sudo commands use pty | 1 | automated |
| 4.3.3 | sudo log file exists | 1 | manual |
| 4.3.4 | no NOPASSWD entries | 2 | manual (audit-only) |
| 4.3.5 | no !authenticate entries | 1 | manual (audit-only) |
| 4.3.6 | sudo auth timeout configured | 1 | manual |
| 4.3.7 | su command restricted via pam_group.so | 1 | manual (audit-only) |

**4.4 — PAM**
| ID | Title | Level | Type |
|----|-------|-------|------|
| 4.4.1.1.1 | pam_passwdqc minlen >= 14 | 1 | manual |
| 4.4.1.1.2 | pam_passwdqc enforce=everyone | 1 | manual |
| 4.4.1.2.1 | pam_unix no nullok | 1 | manual |

**4.5 — User accounts and environment**
| ID | Title | Level | Type |
|----|-------|-------|------|
| 4.5.1.1 | sha512 password hashing | 1 | manual |
| 4.5.1.2 | password expiration <= 365 days | 1 | automated |
| 4.5.1.3 | password warning >= 7 days | 1 | manual |
| 4.5.2.1 | root account GID 0 | 1 | manual |
| 4.5.2.2 | root user umask (audit-only) | 1 | manual |
| 4.5.2.3 | system accounts secured | 1 | manual |
| 4.5.3.1 | nologin not in /etc/shells | 2 | manual |
| 4.5.3.2 | default user umask configured | 1 | manual |

## New tunables (defaults/main.yml)

| Variable | Default | Purpose |
|----------|---------|---------|
| `freebsd_cis_sudo_logfile` | `/var/log/sudo.log` | 4.3.3 sudo log path |
| `freebsd_cis_sudo_timeout` | `15` | 4.3.6 max sudo credential cache (minutes) |
| `freebsd_cis_pam_passwdqc_minlen` | `disabled,14,12,8,6` | 4.4.1.1.1 minlen string |
| `freebsd_cis_pw_max_age` | `365` | 4.5.1.2 max password age (days) |
| `freebsd_cis_pw_warn_days` | `7` | 4.5.1.3 password expiry warning (days) |

## Design notes

- **4.3.4 / 4.3.5 / 4.3.7**: Audit-only (no `REMEDIATE` task). Removing NOPASSWD/!authenticate entries requires operator judgment; modifying /etc/pam.d/su carries lockout risk.
- **4.5.2.2**: Reports current umask values for operator review. Compliance depends on site policy (CIS requires 0027 or more restrictive for root).
- **4.5.1.2 REMEDIATE**: Uses `pw usermod -p +365d` loop — only runs when expiry is absent and `freebsd_cis_remediate: true`.
- Sudoers remediations use `validate: 'visudo -cf %s'` to prevent syntax errors from being written.
- POSIX ERE character classes (`[[:space:]]` etc.) used in all `ansible.builtin.command` grep patterns per FreeBSD portability rules.

## Validation

- `ansible-lint tasks/section_4.yml`: 0 failures, production profile
- One expected complexity/experimental warning (199 tasks — inherent in a complete CIS section file)

## Risks and follow-ups

- PAM controls target `/etc/pam.d/passwd` and `/etc/pam.d/system` — verify these paths match the target FreeBSD 14 installation before enabling remediation.
- Sudoers grep scans only `/usr/local/etc/sudoers`; files in `sudoers.d/` are not automatically scanned. Operators with drop-in files should handle those separately.
- No unit tests exist for section_4 tasks (testing gap noted — shared with Part A).
