### PR TITLE
chore: prohibit heredocs and python3 -c for multi-line content

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ Python 3.11, Ansible 2.16, ansible-lint at production profile.
 - Open PRs with `gh pr create --body-file /tmp/<file>.txt`.
 - Use merge commits (`gh pr merge --merge`).
 - After merge: `git checkout main && git pull origin main && git branch -d <branch>`.
+- Never use heredocs or `python3 -c` for multi-line content. Write all scripts and data to `/tmp/` files with `create_file`, execute them, then delete.
 
 ---
 


### PR DESCRIPTION
## Summary

Add a one-line rule to `copilot-instructions.md` prohibiting heredocs and `python3 -c` for multi-line content.

## Why

Terminal interception in the VS Code agent surface corrupts backticks, quotes, em dashes, and special characters when they appear inside heredocs or `python3 -c "..."` strings. This has caused repeated `SyntaxError` failures during PR review workflows (most recently on PR #10). The fix is consistently using `create_file` to write scripts/data to `/tmp/` files and executing them from disk.

## Validation

Docs-only change. No executable behavior changes; no unit test required per PR instructions.

## Risks and follow-ups

None. The rule codifies existing practice already enforced for `gh` body files.
