### PR TITLE
chore: encode PR #12 guardrails into copilot-instructions.md; rewrite README.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,6 @@ Python 3.11, Ansible 2.16, ansible-lint at production profile.
 - Open PRs with `gh pr create --body-file /tmp/<file>.txt`.
 - Use merge commits (`gh pr merge --merge`).
 - After merge: `git checkout main && git pull origin main && git branch -d <branch>`.
-- Never use heredocs or `python3 -c` for multi-line content. Write all scripts and data to `/tmp/` files with `create_file`, execute them, then delete.
 
 ---
 
@@ -59,6 +58,10 @@ Every CIS control is one top-level block. Target pattern (see `docs/DESIGN.md`):
 - Never modify host state in an audit task.
 - `failed_when: false` is acceptable on remediation tasks when a "stop" may fail because the
   service is already stopped.
+- **`|| true` is banned in REMEDIATE shell/command tasks.** It swallows real errors and can
+  mask false-COMPLIANT results. Use `failed_when: false` instead.
+- Every `stat` task used for compliance checks must carry `failed_when: false` — `stat` raises
+  an error by default when the path does not exist.
 
 ---
 
@@ -80,6 +83,8 @@ Every control block must include at least these three baseline tags: `[rule_<id>
 Additional tags are allowed for special cases: `automated`, `manual`.
 - Add `automated` when remediation is fully automated.
 - Add `manual` when the control requires operator action (e.g. 2.2.12).
+- **Tags must be accurate.** Do not default all controls to `manual`. `automated` vs `manual`
+  drives tooling filters and reporting — an incorrect tag is a silent defect.
 
 ---
 
@@ -119,6 +124,110 @@ Skipped controls appear as `skipped` in Ansible output — do not use `ignore_er
   Use separate tasks for separate glob patterns.
 - **inetd.conf patterns**: entries may have leading whitespace. Audit grep patterns should use
   `^[[:space:]]*<service>[[:space:]]`; replace regexps should use `^\s*<service>\s`.
+- **`regex_search()` in `when:` conditions must append `is not none`.** `regex_search()` returns
+  the matched string on success or `None` on no-match. Ansible's conditional evaluator requires a
+  boolean; a bare string raises `Conditional result was derived from value of type 'str'`. Always
+  write `cis_foo.stdout | regex_search('pattern') is not none`.
+- **`when:` list items that contain inline dict literals must be quoted.** A Jinja2 expression
+  containing `{...}` — e.g. `(cis_foo_stat.stat | default({'exists': false})).exists` — is parsed
+  as a YAML mapping by ansible-lint and causes `schema[tasks]` failures. Quote the entire condition
+  as a YAML string, or restructure to avoid inline dict literals altogether.
+- **POSIX file permission checks**: use digit-based mode inspection in awk — extract the numeric
+  mode string, strip leading zeros (`gsub(/^0+/,"",m)`), and check each digit position
+  independently. Do not use `perm /o+r` style for multi-digit mode thresholds.
+
+---
+
+## Audit Safety Patterns
+
+These patterns prevent the three most common classes of audit defect:
+false-COMPLIANT results, silent remediation failures, and path injection.
+
+### Optional-file audits (false-COMPLIANT prevention)
+
+If an audit reads a file that may not exist (e.g. `/etc/newsyslog.conf`,
+`/etc/security/audit_control`) and the read command is guarded only with
+`2>/dev/null || true`, an absent file produces empty stdout. If `changed_when`
+checks `stdout | trim != ''`, the task reports COMPLIANT when the file doesn't
+exist. Fix pattern:
+
+```yaml
+- name: "<id> | AUDIT | Check <file> exists"
+  ansible.builtin.stat:
+    path: /etc/some/file
+  register: cis_X_X_X_stat
+  failed_when: false
+  check_mode: false
+
+- name: "<id> | AUDIT | <what>"
+  ansible.builtin.shell: awk '...' /etc/some/file
+  register: cis_X_X_X_result
+  changed_when: cis_X_X_X_result.stdout | trim == ''
+  failed_when: false
+  check_mode: false
+  when: cis_X_X_X_stat.stat.exists
+```
+
+The `stat` task itself should use `changed_when: not cis_X_X_X_stat.stat.exists`
+so the absent-file case is flagged as NON-COMPLIANT.
+
+### Optional-file remediations
+
+If a `lineinfile` (or `replace`) targets a file that may not exist and
+`create: false` is set, the task will fail the play when the file is absent.
+Fix pattern:
+
+1. One unconditional `stat` task early in the section, before first use
+   → `register: cis_<name>_stat`, `check_mode: false`, `failed_when: false`.
+2. One `debug` warn task when `not stat.stat.exists`.
+3. All downstream `lineinfile` remediations carry `- cis_<name>_stat.stat.exists`
+   as a `when:` condition.
+
+### Optional-binary pre-flights
+
+When a control audits or remediates using a binary that may not be installed
+(e.g. AIDE, a ports package):
+
+1. `stat` the binary first → `failed_when: false`.
+2. Emit a `debug` warning if absent.
+3. Guard audit and remediation tasks on the stat result.
+
+### Path injection guard
+
+When an audit reads a path value from a config file (e.g. `dir:` from
+`/etc/security/audit_control`) and then interpolates it into a shell `find`,
+`stat`, or `awk` command, validate the path before use:
+
+```yaml
+when:
+  - freebsd_cis_remediate | bool
+  - cis_X_X_X_dir.stdout | trim | regex_search('^/[a-zA-Z0-9/_.-]+$') is not none
+```
+
+This prevents path injection from a malformed or tampered config file.
+Apply to both AUDIT and REMEDIATE tasks that construct shell commands from
+config-sourced data.
+
+---
+
+## Handlers
+
+Any `lineinfile` or `replace` task that modifies an actively-used service
+config must carry `notify:` to trigger a handler reload. Without `notify:` the
+change takes no effect until the service restarts on its own.
+
+Handler declaration pattern:
+```yaml
+- name: Resync auditd
+  ansible.builtin.command: /usr/sbin/audit -s
+  changed_when: false
+  failed_when: false
+```
+
+Then on every `lineinfile` task targeting that config:
+```yaml
+notify: Resync auditd
+```
 
 ---
 
@@ -139,9 +248,9 @@ vars/main.yml           # Internal role metadata (benchmark name/version)
 tasks/main.yml          # Orchestrator: merge exceptions, import sections
 tasks/section_1.yml     # CIS Section 1 — Initial Setup
 tasks/section_2.yml     # CIS Section 2 — Services
-tasks/section_3.yml     # CIS Section 3 — Network (stub)
-tasks/section_4.yml     # CIS Section 4 — Access, Authentication and Authorization (stub)
-tasks/section_5.yml     # CIS Section 5 — Logging and Auditing (stub)
+tasks/section_3.yml     # CIS Section 3 — Network
+ tasks/section_4.yml     # CIS Section 4 — Access, Authentication and Authorization
+ tasks/section_5.yml     # CIS Section 5 — Logging and Auditing
 tasks/section_6.yml     # CIS Section 6 — System Maintenance (stub)
 docs/DESIGN.md          # Canonical patterns and rationale
 docs/ARCHITECTURE.md    # Data flow, modes, file inventory

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -159,6 +159,7 @@ exist. Fix pattern:
   ansible.builtin.stat:
     path: /etc/some/file
   register: cis_X_X_X_stat
+  changed_when: not cis_X_X_X_stat.stat.exists
   failed_when: false
   check_mode: false
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,8 +60,10 @@ Every CIS control is one top-level block. Target pattern (see `docs/DESIGN.md`):
   service is already stopped.
 - **`|| true` is banned in REMEDIATE shell/command tasks.** It swallows real errors and can
   mask false-COMPLIANT results. Use `failed_when: false` instead.
-- Every `stat` task used for compliance checks must carry `failed_when: false` — `stat` raises
-  an error by default when the path does not exist.
+- Every `stat` task used for compliance checks must carry `failed_when: false` — `ansible.builtin.stat`
+  does not error on a missing path (it returns `stat.exists: false`), but can fail due to permission
+  errors or unexpected module failures. `failed_when: false` ensures non-compliance is never masked
+  by a task error and the play continues to the report task.
 
 ---
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ Python 3.11, Ansible 2.16, ansible-lint at production profile.
 - Open PRs with `gh pr create --body-file /tmp/<file>.txt`.
 - Use merge commits (`gh pr merge --merge`).
 - After merge: `git checkout main && git pull origin main && git branch -d <branch>`.
+- Never use heredocs or `python3 -c` for multi-line content. Write all scripts and data to `/tmp/` files with `create_file`, execute them, then delete.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,14 @@
 # Ansible FreeBSD 14 CIS Benchmarks (v1.0.1)
 
-I have a few VPS' in the cloud and want to implement FreeBSD 14 CIS Benchmarks on them. This repository defines an Ansible role pattern for auditing and optionally remediating FreeBSD 14 hosts against CIS Benchmark v1.0.1 controls.
+An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against CIS Benchmark v1.0.1 controls.
 
-## What This Project Does
+## What This Role Does
 
-- Audits CIS controls by default.
-- Marks non-compliant checks as `changed` in Ansible output.
-- Applies remediation only when explicitly enabled.
+- Audits CIS controls by default — no host state is changed unless explicitly enabled.
+- Marks non-compliant checks as `changed` in Ansible output for easy grep/reporting.
+- Applies remediation only when `freebsd_cis_remediate: true`.
 - Supports layered exception handling for environment-specific deviations.
-
-## Core Behavior
-
-The role is designed as a conditional pipeline per control:
-
-1. Exception check: skip rule if it is in the merged exceptions list.
-2. Audit step: run check logic and set status.
-3. Remediation step: run fix logic only when both conditions are true:
-	- the audit indicates non-compliance
-	- `freebsd_cis_remediate` is `true`
+- Audit-only mode (`freebsd_cis_remediate: false`) is safe to run on production hosts at any time.
 
 ## Modes
 
@@ -27,57 +18,156 @@ The role is designed as a conditional pipeline per control:
 | Remediation | `freebsd_cis_remediate: true` | Reports and applies defined fixes |
 | Dry run | `--check` | Simulates remediation intent while validating execution paths |
 
+## Section Coverage
+
+5 of 6 CIS sections are implemented. Section 6 is a stub.
+
+| Section | Title | Status | Controls |
+| --- | --- | --- | --- |
+| 1 | Initial Setup | Implemented | 1.1.1.1 – 1.8.1 |
+| 2 | Services | Implemented | 2.1.1 – 2.2.12 |
+| 3 | Network | Implemented | 3.1.1 – 3.4.1.2 |
+| 4 | Access, Authentication and Authorization | Implemented | 4.1.1.1 – 4.5.3.2 |
+| 5 | Logging and Auditing | Implemented | 5.1.1.1 – 5.3.2 |
+| 6 | System Maintenance | Stub | — |
+
+### Level gating
+
+- Level 1 controls run when `freebsd_cis_level: 1` (default).
+- Level 2 controls are gated by `freebsd_cis_level | int >= 2`. This includes the BSM/audit subsystem controls (5.2.x) and higher-risk network controls.
+
+### Manual controls
+
+Some controls emit COMPLIANT/NON-COMPLIANT but cannot be fully auto-remediated — they require operator review or site-specific configuration. These are tagged `manual`. Examples:
+- **5.1.1.5** — Remote syslog forwarding: the audit detects any remote logging mechanism (syslog `@remote`, Splunk UF, rsyslog, syslog-ng). Automated `syslog.conf` remediation is only applied when `freebsd_cis_syslog_remote_host` is set.
+- **5.1.1.2** — newsyslog.conf log file permissions: flags a permissions violation, but site-specific log rotation configs may intentionally vary.
+- **2.2.12** — Other inetd-managed services: requires operator review of each entry.
+
+### Pre-flight behavior
+
+The role includes pre-flight `stat` checks for optional files and binaries. When a dependency is absent, the role emits a warning and skips related tasks — it does not fail the play. Affected items:
+- `/etc/security/audit_control` — required for Section 5.2.x BSM controls
+- `/etc/syslog.conf` — required for Section 5.1.1.5 syslog forwarding remediation
+- AIDE binary (`/usr/local/bin/aide`) — required for Section 5.3.2 file integrity checks
+
+### Handlers
+
+The handler `Resync auditd` runs `/usr/sbin/audit -s` after any change to `/etc/security/audit_control`. This ensures audit configuration changes take effect immediately without a full audit daemon restart.
+
 ## Exception Model
 
-Two lists are merged into one active list used by each control:
+Two lists merge into one active exceptions set used by each control:
 
-- `freebsd_cis_global_exceptions`
-- `freebsd_cis_local_exceptions`
+```yaml
+freebsd_cis_global_exceptions: []   # role-level skips
+freebsd_cis_local_exceptions: []    # playbook/host-level skips
+```
 
-Effective set:
+Effective set computed in `tasks/main.yml`:
+```yaml
+active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
+```
 
-- `active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"`
+Skipped controls appear as `skipped` in Ansible output.
 
-## Project Layout
+## Variables Reference
 
-- `docs/PROPOSAL.md`: project goals and rationale
-- `docs/DESIGN.md`: implementation conventions and task pattern
-- `docs/ARCHITECTURE.md`: execution flow and file structure
+All operator-tunable variables live in `defaults/main.yml`.
 
-Expected role layout:
+### Core
 
-- `defaults/main.yml`
-- `vars/main.yml`
-- `tasks/main.yml`
-- `tasks/section_N.yml` (one file per CIS section; audit and remediation logic co-located)
+| Variable | Default | Description |
+| --- | --- | --- |
+| `freebsd_cis_remediate` | `false` | Enable remediation. `false` = audit-only. |
+| `freebsd_cis_level` | `1` | CIS profile level (1 or 2). Level 2 enables additional controls. |
+| `freebsd_cis_global_exceptions` | `[]` | Rule IDs to skip at the role level. |
+| `freebsd_cis_local_exceptions` | `[]` | Rule IDs to skip at the playbook or host level. |
+
+### Section 1 — Initial Setup
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `freebsd_cis_tmp_size` | `"2g"` | tmpfs size for `/tmp` when enabling tmpfs via sysrc (1.1.2.1.1). |
+| `freebsd_cis_bootloader_password` | `""` | Bootloader password written to `/boot/loader.conf`. Empty = skip. **Stored in plaintext.** |
+| `freebsd_cis_warning_banner` | `"Authorized users only..."` | Warning banner text for `/etc/motd`, `/etc/issue`, and `/etc/issue.net` (1.6.1–1.6.3). |
+
+### Section 4 — Access, Authentication and Authorization
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `freebsd_cis_sshd_source` | `"base"` | SSH implementation: `base` (FreeBSD base sshd) or `ports` (ports OpenSSH). Derives paths and service name. |
+| `freebsd_cis_sshd_config` | *(derived)* | Path to `sshd_config`. |
+| `freebsd_cis_sshd_bin` | *(derived)* | Path to `sshd` binary. |
+| `freebsd_cis_ssh_bin` | *(derived)* | Path to `ssh` binary. |
+| `freebsd_cis_sshd_service` | *(derived)* | rc.d service name (`sshd` or `openssh`). |
+| `freebsd_cis_sshd_allow_users` | `""` | `AllowUsers` value. Empty = skip remediation. |
+| `freebsd_cis_sshd_allow_groups` | `""` | `AllowGroups` value. Empty = skip remediation. |
+| `freebsd_cis_sshd_deny_users` | `""` | `DenyUsers` value. Empty = skip remediation. |
+| `freebsd_cis_sshd_deny_groups` | `""` | `DenyGroups` value. Empty = skip remediation. |
+| `freebsd_cis_sshd_banner` | `/etc/issue.net` | Banner file path sent to remote users before authentication (4.2.5). |
+| `freebsd_cis_sshd_weak_ciphers` | `"3des-cbc,aes128-cbc,..."` | Comma-separated list of weak ciphers to remove (minus-prefix syntax, 4.2.6). |
+| `freebsd_cis_sshd_client_alive_interval` | `15` | `ClientAliveInterval` in seconds (4.2.7). |
+| `freebsd_cis_sshd_client_alive_count_max` | `3` | `ClientAliveCountMax` (4.2.7). |
+| `freebsd_cis_sshd_weak_kex` | `"diffie-hellman-group1-sha1,..."` | Weak key-exchange algorithms to remove (4.2.11). |
+| `freebsd_cis_sshd_login_grace_time` | `60` | `LoginGraceTime` in seconds (4.2.12). |
+| `freebsd_cis_sshd_log_level` | `"VERBOSE"` | sshd log verbosity (4.2.13). |
+| `freebsd_cis_sshd_weak_macs` | `"hmac-md5,..."` | Weak MAC algorithms to remove (4.2.14). |
+| `freebsd_cis_sshd_max_auth_tries` | `4` | `MaxAuthTries` (4.2.15). |
+| `freebsd_cis_sshd_max_sessions` | `10` | `MaxSessions` (4.2.16). |
+| `freebsd_cis_sshd_max_startups` | `"10:30:60"` | `MaxStartups` throttle (4.2.17). |
+| `freebsd_cis_sudo_logfile` | `/var/log/sudo.log` | sudo log file path (4.3.3). |
+| `freebsd_cis_sudo_timeout` | `15` | sudo credential cache timeout in minutes (4.3.6). |
+| `freebsd_cis_pam_passwdqc_minlen` | `"disabled,14,12,8,6"` | `pam_passwdqc` minlen argument (4.4.1.1.1, 4.4.1.1.2). |
+| `freebsd_cis_pw_max_age` | `365` | Maximum password age in days (4.5.1.2). |
+| `freebsd_cis_pw_warn_days` | `7` | Password expiration warning in days (4.5.1.3). |
+
+### Section 5 — Logging and Auditing
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `freebsd_cis_syslog_remote_host` | `""` | FQDN/IP of remote syslog host for `syslog.conf` remediation (5.1.1.5). Empty = skip syslog.conf change. Audit always runs. |
+| `freebsd_cis_log_files_to_fix` | *(list of `/var/log/...` paths)* | Log files to enforce `0640 root:wheel` or more restrictive on during remediation (5.1.3). |
+| `freebsd_cis_audit_filesz` | `"2M"` | BSM audit trail max file size before rotation (5.2.2.1). |
+| `freebsd_cis_audit_expire_after` | `"10M"` | BSM audit log minimum age/size before expiry (5.2.2.2). |
 
 ## Requirements
 
 - Python 3.11
 - Ansible 2.16
 - FreeBSD 14 target hosts
-- Existing local virtual environment in `venv/`
+- Local virtual environment in `venv/`
 
 ## Local Development
 
-Activate the existing environment:
-
 ```bash
 source venv/bin/activate
+ansible-lint tasks/section_<N>.yml   # lint a single section
 ```
 
-Install or verify Ansible as needed in that environment.
+## Project Layout
+
+```
+defaults/main.yml       # Operator tunables and exception lists
+vars/main.yml           # Internal role metadata (benchmark name/version)
+tasks/main.yml          # Orchestrator: merge exceptions, import sections
+tasks/section_1.yml     # CIS Section 1 — Initial Setup
+tasks/section_2.yml     # CIS Section 2 — Services
+tasks/section_3.yml     # CIS Section 3 — Network
+tasks/section_4.yml     # CIS Section 4 — Access, Authentication and Authorization
+tasks/section_5.yml     # CIS Section 5 — Logging and Auditing
+tasks/section_6.yml     # CIS Section 6 — System Maintenance (stub)
+handlers/main.yml       # Service reload/resync handlers
+docs/DESIGN.md          # Canonical task patterns and rationale
+docs/ARCHITECTURE.md    # Execution flow and file structure
+docs/PROPOSAL.md        # Original project scope and acceptance criteria
+meta/main.yml           # Galaxy metadata
+```
 
 ## Security Notes
 
 - Never commit real credentials or tokens.
 - Treat external payloads as untrusted input.
-- Validate and sanitize user-provided input.
-- In Terraform, avoid patterns that persist plaintext credentials in state.
+- The `freebsd_cis_bootloader_password` variable is stored in **plaintext** in `/boot/loader.conf` — use with caution.
 
 See `.github/instructions/security.instructions.md` for full policy.
-
-## Current Status
-
-This repository currently contains architecture, design, and proposal documentation that define the implementation contract for the role.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 
 | Section | Title | Status | Controls |
 | --- | --- | --- | --- |
-| 1 | Initial Setup | Implemented | 1.1.1.1 – 1.8.1 |
+| 1 | Initial Setup | Implemented | 1.1.1.1 – 1.6.5 |
 | 2 | Services | Implemented | 2.1.1 – 2.2.12 |
 | 3 | Network | Implemented | 3.1.1 – 3.4.1.2 |
 | 4 | Access, Authentication and Authorization | Implemented | 4.1.1.1 – 4.5.3.2 |
@@ -45,7 +45,7 @@ Some controls emit COMPLIANT/NON-COMPLIANT but cannot be fully auto-remediated �
 
 ### Pre-flight behavior
 
-The role includes pre-flight `stat` checks for optional files and binaries. When a dependency is absent, the role emits a warning and skips related tasks — it does not fail the play. Affected items:
+The role includes pre-flight `stat` checks for optional files and binaries. When a dependency is absent, the role warns and guards remediation tasks that require that file or binary — audit tasks may still run and report non-compliance. The play does not fail. Affected items:
 - `/etc/security/audit_control` — required for Section 5.2.x BSM controls
 - `/etc/syslog.conf` — required for Section 5.1.1.5 syslog forwarding remediation
 - AIDE binary (`/usr/local/bin/aide`) — required for Section 5.3.2 file integrity checks

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 
 Some controls emit COMPLIANT/NON-COMPLIANT but cannot be fully auto-remediated — they require operator review or site-specific configuration. These are tagged `manual`. Examples:
 - **5.1.1.5** — Remote syslog forwarding: the audit detects any remote logging mechanism (syslog `@remote`, Splunk UF, rsyslog, syslog-ng). Automated `syslog.conf` remediation is only applied when `freebsd_cis_syslog_remote_host` is set.
-- **5.1.1.2** — newsyslog.conf log file permissions: flags a permissions violation, but site-specific log rotation configs may intentionally vary.
+- **5.1.1.3** — newsyslog.conf log file permissions: flags a permissions violation, but site-specific log rotation configs may intentionally vary.
 - **2.2.12** — Other inetd-managed services: requires operator review of each entry.
 
 ### Pre-flight behavior
@@ -89,7 +89,7 @@ All operator-tunable variables live in `defaults/main.yml`.
 | --- | --- | --- |
 | `freebsd_cis_tmp_size` | `"2g"` | tmpfs size for `/tmp` when enabling tmpfs via sysrc (1.1.2.1.1). |
 | `freebsd_cis_bootloader_password` | `""` | Bootloader password written to `/boot/loader.conf`. Empty = skip. **Stored in plaintext.** |
-| `freebsd_cis_warning_banner` | `"Authorized users only..."` | Warning banner text for `/etc/motd`, `/etc/issue`, and `/etc/issue.net` (1.6.1–1.6.3). |
+| `freebsd_cis_warning_banner` | `"Authorized users only. All activity may be monitored and reported."` | Warning banner text for `/etc/motd`, `/etc/issue`, and `/etc/issue.net` (1.6.1–1.6.3). |
 
 ### Section 4 — Access, Authentication and Authorization
 
@@ -105,13 +105,13 @@ All operator-tunable variables live in `defaults/main.yml`.
 | `freebsd_cis_sshd_deny_users` | `""` | `DenyUsers` value. Empty = skip remediation. |
 | `freebsd_cis_sshd_deny_groups` | `""` | `DenyGroups` value. Empty = skip remediation. |
 | `freebsd_cis_sshd_banner` | `/etc/issue.net` | Banner file path sent to remote users before authentication (4.2.5). |
-| `freebsd_cis_sshd_weak_ciphers` | `"3des-cbc,aes128-cbc,..."` | Comma-separated list of weak ciphers to remove (minus-prefix syntax, 4.2.6). |
+| `freebsd_cis_sshd_weak_ciphers` | `"3des-cbc,aes128-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se"` | Comma-separated list of weak ciphers to remove (minus-prefix syntax, 4.2.6). |
 | `freebsd_cis_sshd_client_alive_interval` | `15` | `ClientAliveInterval` in seconds (4.2.7). |
 | `freebsd_cis_sshd_client_alive_count_max` | `3` | `ClientAliveCountMax` (4.2.7). |
-| `freebsd_cis_sshd_weak_kex` | `"diffie-hellman-group1-sha1,..."` | Weak key-exchange algorithms to remove (4.2.11). |
+| `freebsd_cis_sshd_weak_kex` | `"diffie-hellman-group1-sha1,diffie-hellman-group14-sha1,diffie-hellman-group-exchange-sha1"` | Weak key-exchange algorithms to remove (4.2.11). |
 | `freebsd_cis_sshd_login_grace_time` | `60` | `LoginGraceTime` in seconds (4.2.12). |
 | `freebsd_cis_sshd_log_level` | `"VERBOSE"` | sshd log verbosity (4.2.13). |
-| `freebsd_cis_sshd_weak_macs` | `"hmac-md5,..."` | Weak MAC algorithms to remove (4.2.14). |
+| `freebsd_cis_sshd_weak_macs` | abbreviated; see `defaults/main.yml` | Weak MAC algorithms to remove (4.2.14). Full list in `defaults/main.yml`. |
 | `freebsd_cis_sshd_max_auth_tries` | `4` | `MaxAuthTries` (4.2.15). |
 | `freebsd_cis_sshd_max_sessions` | `10` | `MaxSessions` (4.2.16). |
 | `freebsd_cis_sshd_max_startups` | `"10:30:60"` | `MaxStartups` throttle (4.2.17). |


### PR DESCRIPTION
## Summary

Encodes 11 guardrails into `.github/copilot-instructions.md` derived from 23 rounds of Copilot review during the Section 5 (Logging and Auditing) implementation. Rewrites `README.md` to accurately reflect 5 implemented sections, add a full variables reference table, and document operational behavior (pre-flights, manual controls, handlers).

## Why

The PR #12 review process surfaced recurring defect classes — false-COMPLIANT audits, silent remediation failures, path injection risk, incorrect tags, missing `notify:`, and YAML lint failures from inline dict literals. These are now codified as named patterns so future section implementations don't repeat the same rounds.

## Changes

### `.github/copilot-instructions.md`
- **Control Block Structure > Rules**: added `|| true` ban and `stat` + `failed_when: false` requirement
- **Tags**: added accuracy requirement (`automated` vs `manual` must be correct, not defaulted)
- **FreeBSD/Ansible Portability**: added `regex_search() is not none` rule, `when:` inline dict literal quoting rule, digit-based POSIX file permission check rule
- **New section — Audit Safety Patterns**: four named patterns with fix templates:
  - Optional-file audits (false-COMPLIANT prevention via `stat` pre-check)
  - Optional-file remediations (`stat` + warn + `when:` guard on all consumers)
  - Optional-binary pre-flights (`stat` + warn + guard)
  - Path injection guard (`regex_search` validation before shell interpolation)
- **New section — Handlers**: `lineinfile` on active service config must carry `notify:`
- **File Layout**: sections 3–5 updated from "(stub)" to implemented

### `README.md`
- Section coverage table (5/6 implemented; section 6 stub)
- Level gating, manual controls list, pre-flight behavior, handler documentation
- Full variables reference table grouped by section (core, section 1, section 4, section 5)
- Removed stale "Current Status: docs-only" note

## Validation

Docs-only change — no Ansible tasks modified, no lint target applies. Per PR instructions, pure docs changes are exempt from the unit test requirement.

## Risks and follow-ups

- No functional risk — instructions and README only.
- Follow-up: section_1.yml still uses PASS/FAIL in debug messages instead of COMPLIANT/NON-COMPLIANT (tracked in repo memory). Consider a `fix/section-1-audit-messages` PR.
