### PR TITLE
fix: add missing stat failed_when guards in sections 4 and 5

### DIFF
--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1459,6 +1459,7 @@
         path: /usr/local/etc/sudoers.d
       register: cis_4_3_4_sudoers_d
       changed_when: false
+      failed_when: false
       check_mode: false
 
     - name: "4.3.4 | AUDIT | Check for NOPASSWD in sudoers"
@@ -1509,6 +1510,7 @@
         path: /usr/local/etc/sudoers.d
       register: cis_4_3_5_sudoers_d
       changed_when: false
+      failed_when: false
       check_mode: false
 
     - name: "4.3.5 | AUDIT | Check for !authenticate in sudoers"

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -413,6 +413,19 @@
       failed_when: false
       check_mode: false
 
+    - name: "4.2.2 | AUDIT | Partition private key stat results"
+      ansible.builtin.set_fact:
+        cis_4_2_2_privkey_stats_ok: >-
+          {{ cis_4_2_2_privkey_stats.results
+             | selectattr('stat', 'defined')
+             | list }}
+        cis_4_2_2_privkey_stats_failed: >-
+          {{ cis_4_2_2_privkey_stats.results
+             | rejectattr('stat', 'defined')
+             | list }}
+      changed_when: false
+      check_mode: false
+
     - name: "4.2.2 | AUDIT | Report private key permission state"
       ansible.builtin.debug:
         msg: >-
@@ -426,18 +439,29 @@
                  ((item.stat.mode | int(base=8)) // 64) % 8 not in [4, 6] or
                  (item.stat.mode | int(base=8)) % 64 != 0)
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
-      loop: "{{ cis_4_2_2_privkey_stats.results }}"
+      loop: "{{ cis_4_2_2_privkey_stats_ok }}"
       loop_control:
-        label: "{{ item.stat.path }}"
+        label: "{{ item.stat.path | default(item.item.path | default('unknown_path')) }}"
+
+    - name: "4.2.2 | AUDIT | Report private key stat failures"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: unable to stat private key path ' ~
+             (item.item.path | default('unknown_path')) ~
+             ' — verify file access and permissions' }}
+      loop: "{{ cis_4_2_2_privkey_stats_failed }}"
+      loop_control:
+        label: "{{ item.item.path | default('unknown_path') }}"
 
     - name: "4.2.2 | AUDIT | Summarize private key compliance"
       ansible.builtin.set_fact:
         cis_4_2_2_non_compliant: >-
-          {{ (cis_4_2_2_privkey_stats.results
+          {{ (cis_4_2_2_privkey_stats_failed | length > 0)
+             or (cis_4_2_2_privkey_stats_ok
               | selectattr('stat.pw_name', 'ne', 'root') | list | length > 0)
-             or (cis_4_2_2_privkey_stats.results
+             or (cis_4_2_2_privkey_stats_ok
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
-             or (cis_4_2_2_privkey_stats.results
+             or (cis_4_2_2_privkey_stats_ok
               | rejectattr('stat.mode', 'match', '^0[46]00$') | list | length > 0) }}
       changed_when: cis_4_2_2_non_compliant | bool
       check_mode: false
@@ -448,9 +472,9 @@
         owner: root
         group: wheel
         mode: '0600'
-      loop: "{{ cis_4_2_2_privkey_stats.results }}"
+      loop: "{{ cis_4_2_2_privkey_stats_ok }}"
       loop_control:
-        label: "{{ item.stat.path }}"
+        label: "{{ item.stat.path | default(item.item.path | default('unknown_path')) }}"
       when:
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or
@@ -484,6 +508,19 @@
       failed_when: false
       check_mode: false
 
+    - name: "4.2.3 | AUDIT | Partition public key stat results"
+      ansible.builtin.set_fact:
+        cis_4_2_3_pubkey_stats_ok: >-
+          {{ cis_4_2_3_pubkey_stats.results
+             | selectattr('stat', 'defined')
+             | list }}
+        cis_4_2_3_pubkey_stats_failed: >-
+          {{ cis_4_2_3_pubkey_stats.results
+             | rejectattr('stat', 'defined')
+             | list }}
+      changed_when: false
+      check_mode: false
+
     - name: "4.2.3 | AUDIT | Report public key permission state"
       ansible.builtin.debug:
         msg: >-
@@ -498,18 +535,29 @@
                  (item.stat.mode | int(base=8)) % 8 not in [0, 4] or
                  ((item.stat.mode | int(base=8)) // 8) % 8 not in [0, 4])
              else 'COMPLIANT: ' ~ item.stat.path ~ ' has correct ownership and mode' }}
-      loop: "{{ cis_4_2_3_pubkey_stats.results }}"
+      loop: "{{ cis_4_2_3_pubkey_stats_ok }}"
       loop_control:
-        label: "{{ item.stat.path }}"
+        label: "{{ item.stat.path | default(item.item.path | default('unknown_path')) }}"
+
+    - name: "4.2.3 | AUDIT | Report public key stat failures"
+      ansible.builtin.debug:
+        msg: >-
+          {{ 'NON-COMPLIANT: unable to stat public key path ' ~
+             (item.item.path | default('unknown_path')) ~
+             ' — verify file access and permissions' }}
+      loop: "{{ cis_4_2_3_pubkey_stats_failed }}"
+      loop_control:
+        label: "{{ item.item.path | default('unknown_path') }}"
 
     - name: "4.2.3 | AUDIT | Summarize public key compliance"
       ansible.builtin.set_fact:
         cis_4_2_3_non_compliant: >-
-          {{ (cis_4_2_3_pubkey_stats.results
+          {{ (cis_4_2_3_pubkey_stats_failed | length > 0)
+             or (cis_4_2_3_pubkey_stats_ok
               | selectattr('stat.pw_name', 'ne', 'root') | list | length > 0)
-             or (cis_4_2_3_pubkey_stats.results
+             or (cis_4_2_3_pubkey_stats_ok
               | selectattr('stat.gr_name', 'ne', 'wheel') | list | length > 0)
-             or (cis_4_2_3_pubkey_stats.results
+             or (cis_4_2_3_pubkey_stats_ok
               | rejectattr('stat.mode', 'match', '^0[46][04][04]$') | list | length > 0) }}
       changed_when: cis_4_2_3_non_compliant | bool
       check_mode: false
@@ -520,9 +568,9 @@
         owner: root
         group: wheel
         mode: '0644'
-      loop: "{{ cis_4_2_3_pubkey_stats.results }}"
+      loop: "{{ cis_4_2_3_pubkey_stats_ok }}"
       loop_control:
-        label: "{{ item.stat.path }}"
+        label: "{{ item.stat.path | default(item.item.path | default('unknown_path')) }}"
       when:
         - freebsd_cis_remediate | bool
         - item.stat.pw_name != 'root' or

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -109,12 +109,14 @@
       ansible.builtin.stat:
         path: /var/cron/allow
       register: cis_4_1_1_3_allow
+      failed_when: false
       check_mode: false
 
     - name: "4.1.1.3 | AUDIT | Stat /var/cron/deny"
       ansible.builtin.stat:
         path: /var/cron/deny
       register: cis_4_1_1_3_deny
+      failed_when: false
       check_mode: false
 
     - name: "4.1.1.3 | AUDIT | Evaluate cron access control state"
@@ -190,12 +192,14 @@
       ansible.builtin.stat:
         path: /var/at/at.allow
       register: cis_4_1_2_1_allow
+      failed_when: false
       check_mode: false
 
     - name: "4.1.2.1 | AUDIT | Stat /var/at/at.deny"
       ansible.builtin.stat:
         path: /var/at/at.deny
       register: cis_4_1_2_1_deny
+      failed_when: false
       check_mode: false
 
     - name: "4.1.2.1 | AUDIT | Evaluate at access control state"
@@ -406,6 +410,7 @@
       loop_control:
         label: "{{ item.path }}"
       register: cis_4_2_2_privkey_stats
+      failed_when: false
       check_mode: false
 
     - name: "4.2.2 | AUDIT | Report private key permission state"
@@ -476,6 +481,7 @@
       loop_control:
         label: "{{ item.path }}"
       register: cis_4_2_3_pubkey_stats
+      failed_when: false
       check_mode: false
 
     - name: "4.2.3 | AUDIT | Report public key permission state"

--- a/tasks/section_5.yml
+++ b/tasks/section_5.yml
@@ -377,6 +377,7 @@
       loop_control:
         label: "{{ item }}"
       register: cis_5_1_3_log_stats
+      failed_when: false
       when:
         - freebsd_cis_remediate | bool
         - freebsd_cis_log_files_to_fix | length > 0
@@ -410,6 +411,7 @@
   ansible.builtin.stat:
     path: /etc/security/audit_control
   register: cis_audit_control_stat
+  failed_when: false
   check_mode: false
   tags: [always]
 


### PR DESCRIPTION
## Summary
- add missing `failed_when: false` to `stat` tasks identified in issue #14 in sections 4 and 5
- keeps scope intentionally limited to `tasks/section_4.yml` and `tasks/section_5.yml`

## Validation
- `ansible-lint --profile production tasks/section_4.yml tasks/section_5.yml` passed