### PR TITLE
docs: README and design doc accuracy pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 
 ## Section Coverage
 
-5 of 6 CIS sections are implemented. Section 6 is a stub.
+All 6 CIS sections are implemented.
 
 | Section | Title | Status | Controls |
 | --- | --- | --- | --- |
@@ -33,7 +33,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 | 3 | Network | Implemented | 3.1.1 – 3.4.1.2 |
 | 4 | Access, Authentication and Authorization | Implemented | 4.1.1.1 – 4.5.3.2 |
 | 5 | Logging and Auditing | Implemented | 5.1.1.1 – 5.3.2 |
-| 6 | System Maintenance | Stub | — |
+| 6 | System Maintenance | Implemented | 6.1.1 – 6.2.11 |
 
 ### Level gating
 
@@ -43,6 +43,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 ### Manual controls
 
 Some controls emit COMPLIANT/NON-COMPLIANT but cannot be fully auto-remediated — they require operator review or site-specific configuration. These are tagged `manual`. Examples:
+
 - **5.1.1.5** — Remote syslog forwarding: the audit detects any remote logging mechanism (syslog `@remote`, Splunk UF, rsyslog, syslog-ng). Automated `syslog.conf` remediation is only applied when `freebsd_cis_syslog_remote_host` is set.
 - **5.1.1.3** — newsyslog.conf log file permissions: flags a permissions violation, but site-specific log rotation configs may intentionally vary.
 - **2.2.12** — Other inetd-managed services: requires operator review of each entry.
@@ -50,6 +51,7 @@ Some controls emit COMPLIANT/NON-COMPLIANT but cannot be fully auto-remediated �
 ### Pre-flight behavior
 
 The role includes pre-flight `stat` checks for optional files and binaries. When a dependency is absent, the role warns and guards remediation tasks that require that file or binary — audit tasks may still run and report non-compliance. The play does not fail. Affected items:
+
 - `/etc/security/audit_control` — required for Section 5.2.x BSM controls
 - `/etc/syslog.conf` — required for Section 5.1.1.5 syslog forwarding remediation
 - AIDE binary (`/usr/local/bin/aide`) — required for Section 5.3.2 file integrity checks
@@ -67,7 +69,10 @@ freebsd_cis_global_exceptions: []   # role-level skips
 freebsd_cis_local_exceptions: []    # playbook/host-level skips
 ```
 
-Effective set computed in `tasks/main.yml`:
+Both variables must be YAML lists of string rule IDs. `tasks/main.yml` validates this at
+play start and fails with a clear message if either variable is set to a dict or contains
+non-string elements. The effective set is then computed:
+
 ```yaml
 active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
 ```
@@ -145,12 +150,12 @@ All operator-tunable variables live in `defaults/main.yml`.
 
 ```bash
 source venv/bin/activate
-ansible-lint tasks/section_<N>.yml   # lint a single section
+ansible-lint --profile production tasks/section_<N>.yml   # lint a single section
 ```
 
 ## Project Layout
 
-```
+```bash
 defaults/main.yml       # Operator tunables and exception lists
 vars/main.yml           # Internal role metadata (benchmark name/version)
 tasks/main.yml          # Orchestrator: merge exceptions, import sections
@@ -159,7 +164,7 @@ tasks/section_2.yml     # CIS Section 2 — Services
 tasks/section_3.yml     # CIS Section 3 — Network
 tasks/section_4.yml     # CIS Section 4 — Access, Authentication and Authorization
 tasks/section_5.yml     # CIS Section 5 — Logging and Auditing
-tasks/section_6.yml     # CIS Section 6 — System Maintenance (stub)
+tasks/section_6.yml     # CIS Section 6 — System Maintenance
 handlers/main.yml       # Service reload/resync handlers
 docs/DESIGN.md          # Canonical task patterns and rationale
 docs/ARCHITECTURE.md    # Execution flow and file structure
@@ -174,4 +179,3 @@ meta/main.yml           # Galaxy metadata
 - The `freebsd_cis_bootloader_password` variable is stored in **plaintext** in `/boot/loader.conf` — use with caution.
 
 See `.github/instructions/security.instructions.md` for full policy.
-

--- a/README.md
+++ b/README.md
@@ -69,9 +69,10 @@ freebsd_cis_global_exceptions: []   # role-level skips
 freebsd_cis_local_exceptions: []    # playbook/host-level skips
 ```
 
-Both variables must be YAML lists of string rule IDs. `tasks/main.yml` validates this at
-play start by asserting that all elements are string rule IDs, and fails with a clear
-message when non-string elements are present. The effective set is then computed:
+Both variables are intended to be YAML lists of string rule IDs. At play start,
+`tasks/main.yml` validates that the iterated exception values are string rule IDs and
+fails with a clear message when non-string elements are present. The effective set is
+then computed:
 
 ```yaml
 active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ freebsd_cis_local_exceptions: []    # playbook/host-level skips
 ```
 
 Both variables must be YAML lists of string rule IDs. `tasks/main.yml` validates this at
-play start and fails with a clear message if either variable is set to a dict or contains
-non-string elements. The effective set is then computed:
+play start by asserting that all elements are string rule IDs, and fails with a clear
+message when non-string elements are present. The effective set is then computed:
 
 ```yaml
 active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,6 +1,7 @@
 # ARCHITECTURE.md
 
 ## Logic Flow
+
 The role is built around a conditional execution pipeline. Each CIS control is processed using the following sequence:
 
 1. **Exception Check**: Determine whether the rule ID exists in the `active_exceptions` list. If present, the rule is skipped (Blue/Cyan).
@@ -8,10 +9,12 @@ The role is built around a conditional execution pipeline. Each CIS control is p
 3. **Remediation Phase**: If the raw audit signal indicates non-compliance (for example, `result.rc != 0`, `result.rc == 0`, or a mismatched `stdout` value) and `freebsd_cis_remediate` is set to `true`, run the corresponding remediation task.
 
 Notes:
+
 - Audit tasks still surface non-compliance as `changed` for operator visibility.
 - Remediation gating should use the raw registered result fields directly, not `.changed`, to prevent drift if `changed_when` is later refactored.
 
 ## Data Merging Strategy
+
 Exception handling is initialized during role setup using a `set_fact` operation:
 
 - **Global Exceptions**: Defined in `defaults/main.yml`.
@@ -28,6 +31,7 @@ Exception handling is initialized during role setup using a `set_fact` operation
 | `--check` | **Dry Run** | Simulates remediation changes; validates audit execution. |
 
 ## File Structure
+
 - `defaults/main.yml`: Contains global variables and default accepted states.
 - `vars/main.yml`: Stores internal benchmark-related metadata.
 - `meta/main.yml`: Ansible Galaxy role metadata (platforms, min Ansible version, dependencies).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -3,11 +3,12 @@
 ## Python and Ansible Requirements
 
 * Must be python 3.11-compatible
-* Deployed in a Python venv 
+* Deployed in a Python venv
 * Has an appropriate env.sh that activates the python venv
 * Must be Ansible 2.16-compatible
 
 ## Task Implementation Pattern
+
 Each CIS control is defined as a block to keep audit and remediation logic grouped together.
 
 ```yaml
@@ -54,7 +55,6 @@ conditions are preferred for long-term maintainability in this role.
     active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
 ```
 
-
 ## Layout Recommendations
 
 ### Return States & Visual Indicators
@@ -68,8 +68,8 @@ conditions are preferred for long-term maintainability in this role.
 | `failed` | Red | Any | Unexpected error during audit or remediation task |
 
 ### Variable Naming Conventions
-- `freebsd_cis_remediate`: Boolean flag controlling whether remediation is applied (default: false).
-- `freebsd_cis_global_exceptions`: List of rule IDs defined at the role level.
-- `freebsd_cis_local_exceptions`: List of rule IDs defined by the user (playbook or host-level).
-- `cis_<id>_<purpose>`: Internal variables used to store audit/remediation task results for each rule (for example: `cis_1_1_1_1_kld`, `cis_1_1_2_1_1_mount`).
 
+* `freebsd_cis_remediate`: Boolean flag controlling whether remediation is applied (default: false).
+* `freebsd_cis_global_exceptions`: List of rule IDs defined at the role level.
+* `freebsd_cis_local_exceptions`: List of rule IDs defined by the user (playbook or host-level).
+* `cis_<id>_<purpose>`: Internal variables used to store audit/remediation task results for each rule (for example: `cis_1_1_1_1_kld`, `cis_1_1_2_1_1_mount`).


### PR DESCRIPTION
## Summary

Documentation accuracy pass across `README.md`, `docs/ARCHITECTURE.md`, and `docs/DESIGN.md`. No task file or role behavior changes.

## Why

Several inaccuracies were identified when checking the docs against the current codebase:

- Section 6 (`tasks/section_6.yml`) is fully implemented (6.1.1–6.2.11) but the README reported it as a stub.
- The README `ansible-lint` example was missing `--profile production`, inconsistent with the enforced lint gate.
- The Exception Model section did not mention the type validation assert added in PR #20.
- Minor markdown lint issues in `README.md`, `ARCHITECTURE.md`, and `DESIGN.md` (missing blank lines before lists, trailing whitespace) fixed by user.

## Changes

**`README.md`**
- Section coverage: Section 6 updated from `Stub / —` to `Implemented / 6.1.1 – 6.2.11`
- Intro sentence corrected: "5 of 6... Section 6 is a stub" → "All 6 CIS sections are implemented"
- Project Layout: removed `(stub)` from `tasks/section_6.yml` entry
- Local Development: `ansible-lint` command now includes `--profile production`
- Exception Model: documents the type validation assert and its failure behavior
- Markdown lint fixes (blank lines before lists, trailing newline)

**`docs/ARCHITECTURE.md`** and **`docs/DESIGN.md`**
- Markdown lint fixes (blank lines before lists/paragraphs)

## Validation

- Pure documentation change — no task files touched, no lint gate required.
- All content verified against current codebase (`tasks/section_6.yml`, `tasks/main.yml`, `defaults/main.yml`).

## Risks and follow-ups

None. No executable behavior changed.
