### PR TITLE
fix: warn on silent 4.2.4 skip and surface sshd reload failures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,12 @@ repos:
     hooks:
       - id: detect-secrets
         args: ["--baseline", ".secrets.baseline"]
+
+  - repo: local
+    hooks:
+      - id: ansible-syntax-check
+        name: Ansible syntax check
+        entry: scripts/syntax-check.sh
+        language: script
+        files: (tasks/|handlers/|defaults/|vars/|tests/).*\.ya?ml$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -150,8 +150,14 @@ All operator-tunable variables live in `defaults/main.yml`.
 ## Local Development
 
 ```bash
+python3 -m venv venv
 source venv/bin/activate
+pip install -r requirements-dev.txt
+pre-commit install
+
+pre-commit run --all-files                             # run configured commit gates
 ansible-lint --profile production tasks/section_<N>.yml   # lint a single section
+bash scripts/syntax-check.sh                              # validate playbook syntax
 ```
 
 ## Project Layout

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -124,7 +124,7 @@ freebsd_cis_sudo_timeout: 15
 # 4.4.1.1.1 / 4.4.1.1.2 — pam_passwdqc minlen argument string.
 # Format: disabled,N1,N2,N3,N4 (see pam_passwdqc(8)).
 # N1 must be >= 14 per CIS benchmark.
-freebsd_cis_pam_passwdqc_minlen: "disabled,14,12,8,6"
+freebsd_cis_pam_passwdqc_minlen: "disabled,14,12,8,6"  # pragma: allowlist secret
 
 # -------------------------------------------------------------------
 # Section 4.5 — User accounts and environment

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# Activate the project virtual environment.
+# Activate the project virtual environment and install development dependencies.
 # Usage: source env.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/venv/bin/activate"
+
+python -m pip install -r "${SCRIPT_DIR}/requirements-dev.txt"

--- a/env.sh
+++ b/env.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
-# Activate the project virtual environment and install development dependencies.
+# Activate the project virtual environment.
+# To also install development dependencies, set INSTALL_DEV_REQUIREMENTS=1 when sourcing.
 # Usage: source env.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/venv/bin/activate"
 
-python -m pip install -r "${SCRIPT_DIR}/requirements-dev.txt"
+if [ "${INSTALL_DEV_REQUIREMENTS:-0}" = "1" ]; then
+	python -m pip install -r "${SCRIPT_DIR}/requirements-dev.txt"
+else
+	echo "Development dependencies not installed. Re-run with INSTALL_DEV_REQUIREMENTS=1 to install them."
+fi

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,6 @@
       ansible.builtin.service:
         name: "{{ freebsd_cis_sshd_service }}"
         state: reloaded
-      register: cis_reload_sshd_result
 
   rescue:
     - name: Reload sshd | Warn if reload failed

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,17 +1,17 @@
 ---
 # FreeBSD 14 CIS Benchmark v1.0.1 — Role Handlers
 
+- name: Reload sshd | Validate sshd configuration
+  ansible.builtin.command:
+    argv:
+      - "{{ freebsd_cis_sshd_bin }}"
+      - -t
+      - -f
+      - "{{ freebsd_cis_sshd_config }}"
+  changed_when: false
+
 - name: Reload sshd
   block:
-    - name: Reload sshd | Validate sshd configuration
-      ansible.builtin.command:
-        argv:
-          - "{{ freebsd_cis_sshd_bin }}"
-          - -t
-          - -f
-          - "{{ freebsd_cis_sshd_config }}"
-      changed_when: false
-
     - name: Reload sshd | Reload service
       ansible.builtin.service:
         name: "{{ freebsd_cis_sshd_service }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,6 +2,7 @@
 # FreeBSD 14 CIS Benchmark v1.0.1 — Role Handlers
 
 - name: Reload sshd | Validate sshd configuration
+  listen: Reload sshd
   ansible.builtin.command:
     argv:
       - "{{ freebsd_cis_sshd_bin }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,16 @@
       ansible.builtin.service:
         name: "{{ freebsd_cis_sshd_service }}"
         state: reloaded
+      register: cis_reload_sshd_result
       failed_when: false  # acceptable: sshd may not be running
+
+    - name: Reload sshd | Warn if reload failed
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: sshd reload failed ({{ cis_reload_sshd_result.msg | default('unknown error') }}).
+          The hardened sshd_config has been written to disk but the running sshd daemon
+          may still be using the previous configuration. Restart sshd manually to apply changes.
+      when: cis_reload_sshd_result.failed | default(false) | bool
 
 - name: Reload syslogd
   ansible.builtin.service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,15 +17,14 @@
         name: "{{ freebsd_cis_sshd_service }}"
         state: reloaded
       register: cis_reload_sshd_result
-      failed_when: false  # acceptable: sshd may not be running
 
+  rescue:
     - name: Reload sshd | Warn if reload failed
       ansible.builtin.debug:
         msg: >-
-          WARNING: sshd reload failed ({{ cis_reload_sshd_result.msg | default('unknown error') }}).
+          WARNING: sshd reload failed ({{ ansible_failed_result.msg | default('unknown error') }}).
           The hardened sshd_config has been written to disk but the running sshd daemon
           may still be using the previous configuration. Restart sshd manually to apply changes.
-      when: cis_reload_sshd_result.failed | default(false) | bool
 
 - name: Reload syslogd
   ansible.builtin.service:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@
 
 pre-commit>=4.2.0,<5.0.0
 ansible-core>=2.16.0,<2.17.0
+ansible-lint>=24.0.0,<25.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Development tooling for this role repository
+# Install with: pip install -r requirements-dev.txt
+
+pre-commit>=4.2.0,<5.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 # Install with: pip install -r requirements-dev.txt
 
 pre-commit>=4.2.0,<5.0.0
+ansible-core>=2.16.0,<2.17.0

--- a/scripts/syntax-check.sh
+++ b/scripts/syntax-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Syntax check for FreeBSD CIS Ansible role
 # Validates YAML, Jinja2, and Ansible playbook syntax before commit
 

--- a/scripts/syntax-check.sh
+++ b/scripts/syntax-check.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+if ! command -v ansible-playbook >/dev/null 2>&1; then
+  echo "Error: ansible-playbook was not found in PATH." >&2
+  echo "Install Ansible (for example: python3 -m pip install ansible-core) or activate the correct virtual environment, then re-run this check." >&2
+  exit 1
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 

--- a/scripts/syntax-check.sh
+++ b/scripts/syntax-check.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Syntax check for FreeBSD CIS Ansible role
+# Validates YAML, Jinja2, and Ansible playbook syntax before commit
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Checking Ansible playbook syntax..."
+ansible-playbook --syntax-check "$REPO_ROOT/tests/syntax-check-playbook.yml" \
+  -i "$REPO_ROOT/tests/inventory.ini"
+
+echo "✓ Syntax check passed"

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -610,6 +610,7 @@
           freebsd_cis_sshd_deny_groups are all empty — SSH access restriction (4.2.4)
           will not be remediated. Set at least one variable to enforce access control.
       when:
+        - not (cis_4_2_4_access_configured | bool)
         - freebsd_cis_remediate | bool
         - freebsd_cis_sshd_allow_users | length == 0
         - freebsd_cis_sshd_allow_groups | length == 0

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1832,9 +1832,9 @@
     - name: "4.5.1.1 | AUDIT | Report password hashing state"  # pragma: allowlist secret
       ansible.builtin.debug:
         msg: >-  # pragma: allowlist secret
-           {{ 'COMPLIANT: passwd_format=sha512 is set in /etc/login.conf'
+          {{ 'COMPLIANT: passwd_format=sha512 is set in /etc/login.conf'
              if cis_4_5_1_1_hash.stdout != ''
-              else 'NON-COMPLIANT: passwd_format=sha512 not found in /etc/login.conf' }}
+             else 'NON-COMPLIANT: passwd_format=sha512 not found in /etc/login.conf' }}
 
     - name: "4.5.1.1 | REMEDIATE | Set passwd_format=sha512 in /etc/login.conf"  # pragma: allowlist secret
       ansible.builtin.lineinfile:

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -1817,32 +1817,32 @@
 
 # ---
 
-- name: "4.5.1.1 | Ensure strong password hashing algorithm is configured"
+- name: "4.5.1.1 | Ensure strong password hashing algorithm is configured"  # pragma: allowlist secret
   when: "'4.5.1.1' not in active_exceptions"
   tags: [rule_4.5.1.1, level1, section_4, manual]
   block:
 
     - name: "4.5.1.1 | AUDIT | Check passwd_format in /etc/login.conf"
-      ansible.builtin.command: grep -E ':passwd_format=sha512:' /etc/login.conf
+      ansible.builtin.command: grep -E ':passwd_format=sha512:' /etc/login.conf  # pragma: allowlist secret
       register: cis_4_5_1_1_hash
       changed_when: cis_4_5_1_1_hash.stdout == ''
       failed_when: false
       check_mode: false
 
-    - name: "4.5.1.1 | AUDIT | Report password hashing state"
+    - name: "4.5.1.1 | AUDIT | Report password hashing state"  # pragma: allowlist secret
       ansible.builtin.debug:
-        msg: >-
-          {{ 'COMPLIANT: passwd_format=sha512 is set in /etc/login.conf'
+        msg: >-  # pragma: allowlist secret
+           {{ 'COMPLIANT: passwd_format=sha512 is set in /etc/login.conf'
              if cis_4_5_1_1_hash.stdout != ''
-             else 'NON-COMPLIANT: passwd_format=sha512 not found in /etc/login.conf' }}
+              else 'NON-COMPLIANT: passwd_format=sha512 not found in /etc/login.conf' }}
 
-    - name: "4.5.1.1 | REMEDIATE | Set passwd_format=sha512 in /etc/login.conf"
+    - name: "4.5.1.1 | REMEDIATE | Set passwd_format=sha512 in /etc/login.conf"  # pragma: allowlist secret
       ansible.builtin.lineinfile:
         path: /etc/login.conf
         regexp: '^\s*:passwd_format='
         insertafter: '^default:\\$'
         firstmatch: true
-        line: ":passwd_format=sha512:\\"
+        line: ":passwd_format=sha512:\\"  # pragma: allowlist secret
       when:
         - freebsd_cis_remediate | bool
         - cis_4_5_1_1_hash.stdout == ''

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -602,6 +602,20 @@
              if cis_4_2_4_access_configured | bool
              else 'NON-COMPLIANT: no AllowUsers/AllowGroups/DenyUsers/DenyGroups directive found — set at least one per site policy' }}
 
+    - name: "4.2.4 | WARN | Remediation enabled but all SSH access variables are empty"
+      ansible.builtin.debug:
+        msg: >-
+          WARNING: freebsd_cis_remediate is true but freebsd_cis_sshd_allow_users,
+          freebsd_cis_sshd_allow_groups, freebsd_cis_sshd_deny_users, and
+          freebsd_cis_sshd_deny_groups are all empty — SSH access restriction (4.2.4)
+          will not be remediated. Set at least one variable to enforce access control.
+      when:
+        - freebsd_cis_remediate | bool
+        - freebsd_cis_sshd_allow_users | length == 0
+        - freebsd_cis_sshd_allow_groups | length == 0
+        - freebsd_cis_sshd_deny_users | length == 0
+        - freebsd_cis_sshd_deny_groups | length == 0
+
     - name: "4.2.4 | REMEDIATE | Set AllowUsers if configured"
       ansible.builtin.lineinfile:
         path: "{{ freebsd_cis_sshd_config }}"

--- a/tests/inventory.ini
+++ b/tests/inventory.ini
@@ -1,0 +1,2 @@
+[local]
+localhost ansible_connection=local

--- a/tests/syntax-check-playbook.yml
+++ b/tests/syntax-check-playbook.yml
@@ -1,0 +1,8 @@
+---
+- name: Syntax check playbook for FreeBSD CIS role
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - role: ../
+      vars:
+        freebsd_cis_remediate: false


### PR DESCRIPTION
## Summary

This PR now contains four focused commits:

### Commit 1 — fix: warn when 4.2.4 remediation enabled but all SSH access vars empty (Fixes #23)

Problem:
When `freebsd_cis_remediate: true` and all four SSH access-restriction variables are empty (`freebsd_cis_sshd_allow_users`, `freebsd_cis_sshd_allow_groups`, `freebsd_cis_sshd_deny_users`, `freebsd_cis_sshd_deny_groups`), REMEDIATE tasks in 4.2.4 are skipped without an explicit operator warning.

Fix:
Added a WARN debug task that fires only when remediation is enabled and all four variables are empty, making the intentional no-op explicit.

### Commit 2 — fix: surface sshd reload failure with explicit warning (Fixes #27)

Problem:
The `Reload sshd` handler previously hid reload failures (`failed_when: false`) without surfacing that runtime config was not reloaded.

Fix:
Added result capture and warning output so reload failures are explicit and actionable.

### Commit 3 — chore: add syntax-check pre-commit scaffold

Added a shared syntax-check gate for developers:
- `scripts/syntax-check.sh`
- `tests/syntax-check-playbook.yml`
- `tests/inventory.ini`
- local pre-commit hook in `.pre-commit-config.yaml`
- developer bootstrap docs in `README.md`
- `requirements-dev.txt` for reproducible tooling install

### Commit 4 — chore: allowlist detect-secrets benchmark keywords

Addressed detect-secrets false positives for CIS benchmark/password-hashing keyword strings in:
- `defaults/main.yml`
- `tasks/section_4.yml`

No runtime behavior changes in this commit; only scanner allowlist pragmas.

## Why

- Fixes two operator-visibility defects that could otherwise create a false sense of SSH hardening success.
- Adds a reusable syntax-check gate so contributors catch syntax issues earlier.
- Keeps detect-secrets enabled and passing while documenting false positives inline.

## Validation performed

- `ansible-lint --profile production tasks/section_4.yml` — pass
- `ansible-lint --profile production handlers/main.yml` — pass
- `source venv/bin/activate && pre-commit run --all-files` — pass
  - Detect secrets — pass
  - Ansible syntax check — pass
- `source venv/bin/activate && bash scripts/syntax-check.sh` — pass

## Risks and follow-ups

- Fix commits are warning/reporting improvements; intended host-state behavior is unchanged.
- Pre-commit hook behavior is local-clone scoped; contributors must run bootstrap (`pip install -r requirements-dev.txt` and `pre-commit install`) to enable automatic commit-time gating.
- Follow-up: remaining issues #24, #25, #26 are still open and can be handled in priority order.
