### PR TITLE
fix: raise freebsd_cis_audit_expire_after default and add ansible-lint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,10 @@ repos:
         language: script
         files: (tasks/|handlers/|defaults/|vars/|tests/).*\.ya?ml$
         pass_filenames: false
+
+      - id: ansible-lint
+        name: Ansible lint
+        entry: scripts/lint-check.sh
+        language: script
+        files: (tasks/|handlers/|defaults/|vars/).*\.ya?ml$
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All operator-tunable variables live in `defaults/main.yml`.
 | `freebsd_cis_syslog_remote_host` | `""` | FQDN/IP of remote syslog host for `syslog.conf` remediation (5.1.1.5). Empty = skip syslog.conf change. Audit always runs. |
 | `freebsd_cis_log_files_to_fix` | *(list of `/var/log/...` paths)* | Log files to enforce `0640 root:wheel` or more restrictive on during remediation (5.1.3). |
 | `freebsd_cis_audit_filesz` | `"2M"` | BSM audit trail max file size before rotation (5.2.2.1). |
-| `freebsd_cis_audit_expire_after` | `"10M"` | BSM audit log minimum age/size before expiry (5.2.2.2). |
+| `freebsd_cis_audit_expire_after` | `"60d and 512M"` | BSM audit log minimum age/size before expiry (5.2.2.2). Age+size conjunction ensures logs survive at least 60 days AND 512 MB before expiry. **Avoid small size-only values** (e.g. `10M`) — on a busy host audit logs can exceed that threshold in minutes, destroying forensic evidence. A pre-flight warning is emitted at role startup when a size-only value below 100 MB is detected. |
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All operator-tunable variables live in `defaults/main.yml`.
 | `freebsd_cis_syslog_remote_host` | `""` | FQDN/IP of remote syslog host for `syslog.conf` remediation (5.1.1.5). Empty = skip syslog.conf change. Audit always runs. |
 | `freebsd_cis_log_files_to_fix` | *(list of `/var/log/...` paths)* | Log files to enforce `0640 root:wheel` or more restrictive on during remediation (5.1.3). |
 | `freebsd_cis_audit_filesz` | `"2M"` | BSM audit trail max file size before rotation (5.2.2.1). |
-| `freebsd_cis_audit_expire_after` | `"60d and 512M"` | BSM audit log minimum age/size before expiry (5.2.2.2). Age+size conjunction ensures logs survive at least 60 days AND 512 MB before expiry. **Avoid small size-only values** (e.g. `10M`) — on a busy host audit logs can exceed that threshold in minutes, destroying forensic evidence. A pre-flight warning is emitted at role startup when a size-only value below 100 MB is detected. |
+| `freebsd_cis_audit_expire_after` | `"60d and 512M"` | BSM audit log minimum age/size before expiry (5.2.2.2). Age+size conjunction ensures logs survive at least 60 days AND 512 MB before expiry. **Avoid small size-only values** (e.g. `10M`) — on a busy host audit logs can exceed that threshold in minutes, destroying forensic evidence. A pre-flight warning is emitted at role startup when a size-only value below 100 MiB is detected. |
 
 ## Requirements
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -164,7 +164,7 @@ freebsd_cis_audit_filesz: "2M"
 
 # 5.2.2.2 — Minimum age/size before audit logs expire.
 # Supports age (e.g. 60d, 1y) and/or size (e.g. 512M, 2G) with AND/OR conjunction.
-# SECURITY: A size-only default below 100 MB is dangerous — on a busy or actively probed
+# SECURITY: A size-only default below 100 MiB is dangerous — on a busy or actively probed
 # host, BSM audit logs can exceed that threshold within minutes, causing auditd to purge
 # forensic evidence before it is forwarded or reviewed. The default uses an age+size
 # conjunction so logs are retained for at least 60 days AND 512 MB has accumulated.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -163,6 +163,11 @@ freebsd_cis_log_files_to_fix:
 freebsd_cis_audit_filesz: "2M"
 
 # 5.2.2.2 — Minimum age/size before audit logs expire.
-# Supports age (60d, 1y) and/or size (1G) with AND/OR conjunction.
-# Default: 10M (do not auto-delete until 10M accumulated).
-freebsd_cis_audit_expire_after: "10M"
+# Supports age (e.g. 60d, 1y) and/or size (e.g. 512M, 2G) with AND/OR conjunction.
+# SECURITY: A size-only default below 100 MB is dangerous — on a busy or actively probed
+# host, BSM audit logs can exceed that threshold within minutes, causing auditd to purge
+# forensic evidence before it is forwarded or reviewed. The default uses an age+size
+# conjunction so logs are retained for at least 60 days AND 512 MB has accumulated.
+# Tune this value to fit your retention and disk-space requirements; avoid small
+# size-only values unless you have a forwarding pipeline confirmed to be running.
+freebsd_cis_audit_expire_after: "60d and 512M"

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # ansible-lint pre-commit hook for FreeBSD CIS Ansible role
-# Runs ansible-lint at the production profile against all task files.
+# Runs ansible-lint at the production profile against tasks/, handlers/, defaults/, and vars/.
 
 set -e
 

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# ansible-lint pre-commit hook for FreeBSD CIS Ansible role
+# Runs ansible-lint at the production profile against all task files.
+
+set -e
+
+if ! command -v ansible-lint >/dev/null 2>&1; then
+  echo "Error: ansible-lint was not found in PATH." >&2
+  echo "Activate the virtual environment (source venv/bin/activate) or install" >&2
+  echo "development dependencies (pip install -r requirements-dev.txt), then re-run." >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+
+echo "Running ansible-lint (production profile)..."
+ansible-lint --profile production "$REPO_ROOT/tasks/"
+
+echo "✓ ansible-lint passed"

--- a/scripts/lint-check.sh
+++ b/scripts/lint-check.sh
@@ -15,6 +15,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 
 echo "Running ansible-lint (production profile)..."
-ansible-lint --profile production "$REPO_ROOT/tasks/"
+ansible-lint --profile production \
+  "$REPO_ROOT/tasks/" \
+  "$REPO_ROOT/handlers/" \
+  "$REPO_ROOT/defaults/" \
+  "$REPO_ROOT/vars/"
 
 echo "✓ ansible-lint passed"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,9 +29,11 @@
       forwarded or reviewed. Consider a value such as '60d and 512M' so logs survive long enough
       for review or forwarding.
   when: >-
-    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[BKbk]$') is not none) or
-    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[Mm]$') is not none and
-    (freebsd_cis_audit_expire_after | regex_replace('[^0-9]', '') | int) < 100)
+    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[BKMbkm]$') is not none) and
+    (((freebsd_cis_audit_expire_after | regex_replace('[^0-9]', '') | int) *
+    (1048576 if (freebsd_cis_audit_expire_after | lower | regex_search('m$') is not none)
+    else 1024 if (freebsd_cis_audit_expire_after | lower | regex_search('k$') is not none)
+    else 1)) < 104857600)
   tags: [always]
 
 - name: "Section 1 | Initial Setup"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,15 +24,15 @@
   ansible.builtin.debug:
     msg: >-
       SECURITY WARNING: freebsd_cis_audit_expire_after is '{{ freebsd_cis_audit_expire_after }}',
-      a size-only threshold below 100 MB. On a busy or actively probed host, BSM audit logs can
+      a size-only threshold below 100 MiB. On a busy or actively probed host, BSM audit logs can
       exceed this within minutes, causing auditd to auto-delete forensic evidence before it is
       forwarded or reviewed. Consider a value such as '60d and 512M' so logs survive long enough
       for review or forwarding.
   when: >-
-    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[BKMbkm]$') is not none) and
-    (((freebsd_cis_audit_expire_after | regex_replace('[^0-9]', '') | int) *
-    (1048576 if (freebsd_cis_audit_expire_after | lower | regex_search('m$') is not none)
-    else 1024 if (freebsd_cis_audit_expire_after | lower | regex_search('k$') is not none)
+    (freebsd_cis_audit_expire_after | trim | regex_search('^[0-9]+[BKMbkm]$') is not none) and
+    (((freebsd_cis_audit_expire_after | trim | regex_replace('[^0-9]', '') | int) *
+    (1048576 if (freebsd_cis_audit_expire_after | trim | lower | regex_search('m$') is not none)
+    else 1024 if (freebsd_cis_audit_expire_after | trim | lower | regex_search('k$') is not none)
     else 1)) < 104857600)
   tags: [always]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,20 @@
     active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
   tags: [always]
 
+- name: "Initialize | Warn — freebsd_cis_audit_expire_after is a small size-only value"
+  ansible.builtin.debug:
+    msg: >-
+      SECURITY WARNING: freebsd_cis_audit_expire_after is '{{ freebsd_cis_audit_expire_after }}',
+      a size-only threshold below 100 MB. On a busy or actively probed host, BSM audit logs can
+      exceed this within minutes, causing auditd to auto-delete forensic evidence before it is
+      forwarded or reviewed. Consider a value such as '60d and 512M' so logs survive long enough
+      for review or forwarding.
+  when: >-
+    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[BKbk]$') is not none) or
+    (freebsd_cis_audit_expire_after | regex_search('^[0-9]+[Mm]$') is not none and
+    (freebsd_cis_audit_expire_after | regex_replace('[^0-9]', '') | int) < 100)
+  tags: [always]
+
 - name: "Section 1 | Initial Setup"
   ansible.builtin.import_tasks: section_1.yml
   tags: section_1


### PR DESCRIPTION
## Summary

Raises the default value of `freebsd_cis_audit_expire_after` from `"10M"` to `"60d and 512M"` and adds a runtime warning when a dangerously small value is configured. Also adds `ansible-lint` as a pre-commit hook so lint failures are caught at commit time rather than deferred to CI or manual runs.

Closes #26.

## Why

The previous default of `10M` (10 MB) allowed BSM audit logs to be automatically purged within minutes on a busy or actively probed host — destroying forensic evidence before it could be forwarded or reviewed. The issue describes an adversary using audit noise (failed logins, file-access probes, `execve` calls) to accelerate rotation past the threshold.

## Changes

### `defaults/main.yml`
- Default changed from `"10M"` → `"60d and 512M"`: an age+size conjunction so logs survive at least 60 days **and** 512 MB of audit data has accumulated before expiry.
- Comment expanded to document the security implication of small size-only values.

### `tasks/main.yml`
- New `Initialize | Warn` task (tagged `always`) that emits a `SECURITY WARNING` debug message at role startup when `freebsd_cis_audit_expire_after` is a size-only value below 100 MB (covers B/K suffixes and M values < 100). Fires even in audit-only mode so operators are warned without any host changes.

### `README.md`
- Table entry updated to reflect the new default and document the security risk of small size-only values and the pre-flight warning behaviour.

### `scripts/lint-check.sh` *(new)*
- Mirrors `scripts/syntax-check.sh`. Checks that `ansible-lint` is on PATH (with a clear error message directing to the venv), then runs `ansible-lint --profile production tasks/`. Exits non-zero on any lint failure.

### `.pre-commit-config.yaml`
- New `ansible-lint` local hook that invokes `scripts/lint-check.sh`. Triggers on changes to `tasks/`, `handlers/`, `defaults/`, or `vars/` YAML files. `pass_filenames: false` so the full task tree is always evaluated. Runs after the existing `ansible-syntax-check` hook.

## Validation

- `pre-commit run ansible-lint --all-files` → Passed
- `pre-commit run ansible-syntax-check --all-files` → Passed
- `ansible-lint --profile production tasks/main.yml tasks/section_5.yml` → 0 failures

## Risks and Follow-ups

- **Operator action required**: anyone relying on the `"10M"` default to limit disk usage must explicitly set `freebsd_cis_audit_expire_after` in their inventory. The pre-flight warning will alert them if they set a value below 100 MB.
- The warning detection covers `B`, `K`, and `M` (case-insensitive) size-only strings. Values using `G` or `T` suffixes are considered safe and do not trigger a warning.
- No change to the `5.2.2.2` remediation task itself — it continues to write whatever value the operator provides to `audit_control`.
