### PR TITLE
fix: guard 1.2.2 pkg audit against bootstrap stub hang

### DIFF
--- a/tasks/section_1.yml
+++ b/tasks/section_1.yml
@@ -840,12 +840,29 @@
   when: "'1.2.2' not in active_exceptions"
   tags: [rule_1.2.2, level1, section_1]
   block:
+    # Guard against the pkg bootstrap stub hanging: the stub at /usr/sbin/pkg
+    # prompts for interactive input when pkg is not yet bootstrapped.
+    # Only run pkg -vv when the real pkg binary is present.
+    - name: "1.2.2 | AUDIT | Check if pkg is bootstrapped"
+      ansible.builtin.stat:
+        path: /usr/local/sbin/pkg
+      register: cis_1_2_2_pkg_stat
+      changed_when: not cis_1_2_2_pkg_stat.stat.exists
+      failed_when: false
+      check_mode: false
+
+    - name: "1.2.2 | AUDIT | Warn if pkg is not bootstrapped"
+      ansible.builtin.debug:
+        msg: "NON-COMPLIANT: pkg is not bootstrapped — no repository configuration possible"
+      when: not cis_1_2_2_pkg_stat.stat.exists
+
     - name: "1.2.2 | AUDIT | Check pkg repository configuration" # noqa: risky-shell-pipe
       ansible.builtin.shell: pkg -vv 2>/dev/null | sed '1,/^Repositories/d'
       register: cis_1_2_2_repos
       changed_when: not (cis_1_2_2_repos.rc == 0 and cis_1_2_2_repos.stdout | length > 0)
       failed_when: false
       check_mode: false
+      when: cis_1_2_2_pkg_stat.stat.exists
 
     - name: "1.2.2 | AUDIT | Report repository configuration"
       ansible.builtin.debug:
@@ -853,6 +870,7 @@
           {{ 'COMPLIANT: pkg repository configuration found — verify settings match site policy'
              if cis_1_2_2_repos.rc == 0 and cis_1_2_2_repos.stdout | length > 0
              else 'NON-COMPLIANT: unable to read pkg repository configuration' }}
+      when: cis_1_2_2_pkg_stat.stat.exists
 
 # ---
 

--- a/tasks/section_1.yml
+++ b/tasks/section_1.yml
@@ -853,7 +853,9 @@
 
     - name: "1.2.2 | AUDIT | Warn if pkg is not bootstrapped"
       ansible.builtin.debug:
-        msg: "NON-COMPLIANT: pkg is not bootstrapped — no repository configuration possible"
+        msg: >-
+          NON-COMPLIANT: pkg is not bootstrapped — cannot audit repository
+          configuration via pkg -vv because /usr/local/sbin/pkg is absent
       when: not cis_1_2_2_pkg_stat.stat.exists
 
     - name: "1.2.2 | AUDIT | Check pkg repository configuration" # noqa: risky-shell-pipe


### PR DESCRIPTION
## Summary

Guard the 1.2.2 `pkg -vv` audit task against hanging on a fresh FreeBSD instance where pkg has not yet been bootstrapped.

## Why

On a freshly provisioned FreeBSD host, `/usr/sbin/pkg` is the bootstrap stub. Running `pkg -vv` causes the stub to print an interactive prompt ("Do you want to fetch and install it now? [y/N]:") and wait for TTY input. Ansible has no TTY to answer, so the task hangs indefinitely.

This was observed on a fresh FreeBSD 14.4-RELEASE AWS instance.

## Change

Add a stat pre-flight on `/usr/local/sbin/pkg` (the real pkg binary) before the `pkg -vv` command:

- If absent: emit a `NON-COMPLIANT` debug message and skip the audit command entirely.
- If present: run the existing `pkg -vv | sed ...` audit unchanged.

This follows the "Optional-binary pre-flights" pattern documented in `.github/copilot-instructions.md` under Audit Safety Patterns.

## Validation

- `ansible-lint --profile production tasks/section_1.yml` — 0 failures
- Pre-commit hooks passed (detect-secrets, syntax-check, ansible-lint)
- Confirmed unblocked on FreeBSD 14.4-RELEASE AWS instance

## Risks and Follow-ups

- **Low risk** — audit-only change; no remediation logic modified.
- Follow-up: 1.2.3 has the same bootstrap problem for its `pkg upgrade -n` audit task — tracked separately.
