### PR TITLE
fix: guard 4.2.x remediations on sshd_config stat pre-flight

### DIFF
--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -342,6 +342,21 @@
          else 'sshd -T: effective configuration query succeeded' }}
   changed_when: cis_4_2_sshd_config_dump.rc != 0
 
+- name: "4.2 | PREFLIGHT | Stat sshd_config path"
+  ansible.builtin.stat:
+    path: "{{ freebsd_cis_sshd_config }}"
+  register: cis_4_2_sshd_config_stat
+  failed_when: false
+  check_mode: false
+
+- name: "4.2 | PREFLIGHT | Warn if sshd_config not found"
+  ansible.builtin.debug:
+    msg: >-
+      WARNING: {{ freebsd_cis_sshd_config }} does not exist — verify
+      freebsd_cis_sshd_source ('{{ freebsd_cis_sshd_source }}') matches
+      the installed sshd on this host. All 4.2.x remediation tasks will be skipped.
+  when: not cis_4_2_sshd_config_stat.stat.exists
+
 # ---
 
 - name: "4.2.1 | Ensure permissions on /etc/ssh/sshd_config are configured"
@@ -630,6 +645,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - freebsd_cis_sshd_allow_users | length > 0
 
     - name: "4.2.4 | REMEDIATE | Set AllowGroups if configured"
@@ -645,6 +661,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - freebsd_cis_sshd_allow_groups | length > 0
 
     - name: "4.2.4 | REMEDIATE | Set DenyUsers if configured"
@@ -660,6 +677,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - freebsd_cis_sshd_deny_users | length > 0
 
     - name: "4.2.4 | REMEDIATE | Set DenyGroups if configured"
@@ -675,6 +693,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - freebsd_cis_sshd_deny_groups | length > 0
 
 # ---
@@ -715,6 +734,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_5_banner_val != freebsd_cis_sshd_banner
 
 # ---
@@ -763,6 +783,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_6_weak_found | length > 0
 
 # ---
@@ -811,6 +832,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_7_interval | int) == 0
 
     - name: "4.2.7 | REMEDIATE | Set ClientAliveCountMax"
@@ -826,6 +848,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_7_countmax | int) == 0
 
 # ---
@@ -865,6 +888,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_8_val != 'yes'
 
 # ---
@@ -904,6 +928,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_9_val != 'no'
 
 # ---
@@ -943,6 +968,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_10_val != 'yes'
 
 # ---
@@ -991,6 +1017,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_11_weak_found | length > 0
 
 # ---
@@ -1031,6 +1058,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_12_val | int) == 0 or (cis_4_2_12_val | int) > 60
 
 # ---
@@ -1070,6 +1098,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_13_val not in ['INFO', 'VERBOSE']
 
 # ---
@@ -1118,6 +1147,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_14_weak_found | length > 0
 
 # ---
@@ -1157,6 +1187,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_15_val | int) > 4
 
 # ---
@@ -1196,6 +1227,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_16_val | int) > 10
 
 # ---
@@ -1249,6 +1281,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - (cis_4_2_17_start | int) > 10 or
           (cis_4_2_17_rate | int) > 30 or
           (cis_4_2_17_full | int) > 60
@@ -1290,6 +1323,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_18_val != 'no'
 
 # ---
@@ -1329,6 +1363,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_19_val != 'no'
 
 # ---
@@ -1368,6 +1403,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_20_val != 'no'
 
 # ---
@@ -1407,6 +1443,7 @@
       notify: Reload sshd
       when:
         - freebsd_cis_remediate | bool
+        - cis_4_2_sshd_config_stat.stat.exists
         - cis_4_2_21_val != 'yes'
 
 # =============================================================

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -342,19 +342,22 @@
          else 'sshd -T: effective configuration query succeeded' }}
   changed_when: cis_4_2_sshd_config_dump.rc != 0
 
-- name: "4.2 | PREFLIGHT | Stat sshd_config path"
+- name: "4.2 | PRE-FLIGHT | Stat sshd_config path"
   ansible.builtin.stat:
     path: "{{ freebsd_cis_sshd_config }}"
   register: cis_4_2_sshd_config_stat
+  tags: [always]
   failed_when: false
   check_mode: false
 
-- name: "4.2 | PREFLIGHT | Warn if sshd_config not found"
+- name: "4.2 | PRE-FLIGHT | Warn if sshd_config not found"
   ansible.builtin.debug:
     msg: >-
       WARNING: {{ freebsd_cis_sshd_config }} does not exist — verify
       freebsd_cis_sshd_source ('{{ freebsd_cis_sshd_source }}') matches
-      the installed sshd on this host. All 4.2.x remediation tasks will be skipped.
+      the installed sshd on this host. All remediations that modify sshd_config
+      will be skipped.
+  tags: [always]
   when: not cis_4_2_sshd_config_stat.stat.exists
 
 # ---


### PR DESCRIPTION
## Summary

Add a pre-flight `stat` task before the 4.2.1 block that checks whether `freebsd_cis_sshd_config` exists on the target host. Guard all 21 `lineinfile` remediation tasks in 4.2.4–4.2.21 on `cis_4_2_sshd_config_stat.stat.exists`. Emit an actionable warning when the file is absent.

## Why

Running with `freebsd_cis_remediate=true` against a host where `sshd_config` does not exist at the configured path (e.g. `freebsd_cis_sshd_source=ports` but ports SSH not installed, or wrong source value for the host) caused a hard fatal failure:

```
fatal: [host]: FAILED! => {"changed": false, "msg": "Destination /usr/local/etc/ssh/sshd_config does not exist !", "rc": 257}
```

The role should warn and skip gracefully, consistent with the optional-file remediation pattern in `docs/DESIGN.md`.

## Changes

- `tasks/section_4.yml`: add `4.2 | PREFLIGHT | Stat sshd_config path` and `4.2 | PREFLIGHT | Warn if sshd_config not found` tasks before the 4.2.1 block
- Add `- cis_4_2_sshd_config_stat.stat.exists` condition to all 21 `lineinfile` remediation tasks in 4.2.4–4.2.21

## Validation

- `ansible-lint --profile production tasks/section_4.yml` — 0 failures, 0 warnings
- Pre-commit hooks (detect-secrets, syntax check, lint) all passed

## Risks and follow-ups

Low risk — change is additive only; existing passing hosts are unaffected. Hosts with a misconfigured `freebsd_cis_sshd_source` now skip remediation with a warning instead of failing the play.