### PR TITLE
fix: 5.3.1 correct AIDE paths and strip file:// URI from aide.conf

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -98,5 +98,5 @@ both `database=` and `database_out=` lines before running `aide --init`. All pat
 init and move tasks use `/var/db/aide/databases/` (the correct FreeBSD path).
 
 **Verified against:** FreeBSD 14 with `security/aide` port installed; aide binary at
-`/usr/local/bin/aide`; aide.conf at `/usr/local/etc/aide.conf` (line 75 and corresponding
-`database_out` line both affected).
+`/usr/local/bin/aide`; aide.conf at `/usr/local/etc/aide.conf` (the `database=` and
+`database_out=` entries both affected).

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -73,3 +73,30 @@ conditions are preferred for long-term maintainability in this role.
 * `freebsd_cis_global_exceptions`: List of rule IDs defined at the role level.
 * `freebsd_cis_local_exceptions`: List of rule IDs defined by the user (playbook or host-level).
 * `cis_<id>_<purpose>`: Internal variables used to store audit/remediation task results for each rule (for example: `cis_1_1_1_1_kld`, `cis_1_1_2_1_1_mount`).
+
+## Benchmark Fidelity and Known Divergences
+
+The CIS FreeBSD 14 Benchmark v1.0.1 is the authoritative source for control intent, but it contains
+errors — most commonly Linux-ism paths and procedures copied into a FreeBSD benchmark. Where the
+role diverges from the benchmark text for correctness, the divergence is documented here and
+inline in the task file.
+
+### 5.3.1 — AIDE paths and aide.conf URI scheme
+
+**Benchmark text:** specifies `/var/lib/aide/` for database paths (a Linux FHS path that does not
+exist on FreeBSD).
+
+**Actual FreeBSD port layout:** the `security/aide` port writes databases to
+`/var/db/aide/databases/` and ships `/usr/local/etc/aide.conf` with `database=` and `database_out=`
+values using `file:///` URI prefixes (e.g. `database=file:///var/db/aide/databases/aide.db`).
+
+**Problem:** The AIDE binary from the FreeBSD port does not support the `file://` URI scheme — it
+produces `ERROR: unexpected character: ':'` and exits non-zero.
+
+**Role fix:** A remediation task uses `ansible.builtin.replace` to strip the `file://` prefix from
+both `database=` and `database_out=` lines before running `aide --init`. All path references in the
+init and move tasks use `/var/db/aide/databases/` (the correct FreeBSD path).
+
+**Verified against:** FreeBSD 14 with `security/aide` port installed; aide binary at
+`/usr/local/bin/aide`; aide.conf at `/usr/local/etc/aide.conf` (line 75 and corresponding
+`database_out` line both affected).

--- a/tasks/section_5.yml
+++ b/tasks/section_5.yml
@@ -1624,22 +1624,64 @@
         - freebsd_cis_remediate | bool
         - cis_5_3_1_aide.stdout | trim == ''
 
+    # Benchmark divergence: CIS FreeBSD 14 v1.0.1 specifies /var/lib/aide/ (Linux path).
+    # The FreeBSD AIDE port (security/aide) uses /var/db/aide/databases/ and ships
+    # aide.conf with file:// URI prefixes that the port binary does not support.
+    # This role patches aide.conf to strip the file:// prefix and uses the correct
+    # FreeBSD paths throughout.
+
+    - name: "5.3.1 | REMEDIATE | Stat aide.conf"
+      ansible.builtin.stat:
+        path: /usr/local/etc/aide.conf
+      register: cis_5_3_1_conf_stat
+      failed_when: false
+      check_mode: false
+
+    - name: "5.3.1 | REMEDIATE | Warn if aide.conf not found"
+      ansible.builtin.debug:
+        msg: "WARNING: /usr/local/etc/aide.conf not found — AIDE config fix and database init skipped"
+      when:
+        - freebsd_cis_remediate | bool
+        - not cis_5_3_1_conf_stat.stat.exists
+
+    - name: "5.3.1 | REMEDIATE | Fix file:// URI scheme in aide.conf database paths"
+      ansible.builtin.replace:
+        path: /usr/local/etc/aide.conf
+        regexp: '^(database(?:_out)?=)file://'
+        replace: '\1'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_5_3_1_conf_stat.stat.exists
+
+    - name: "5.3.1 | REMEDIATE | Ensure AIDE database directory exists"
+      ansible.builtin.file:
+        path: /var/db/aide/databases
+        state: directory
+        owner: root
+        group: wheel
+        mode: '0700'
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_5_3_1_conf_stat.stat.exists
+
     - name: "5.3.1 | REMEDIATE | Initialize AIDE database"
       ansible.builtin.command: /usr/local/bin/aide --init
       args:
-        creates: /var/lib/aide/aide.db.new.gz
+        creates: /var/db/aide/databases/aide.db.new
+      changed_when: true
       when:
         - freebsd_cis_remediate | bool
-        - cis_5_3_1_aide.stdout | trim == ''
+        - cis_5_3_1_conf_stat.stat.exists
 
     - name: "5.3.1 | REMEDIATE | Move AIDE database into place"
-      ansible.builtin.command: mv /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
+      ansible.builtin.command: mv /var/db/aide/databases/aide.db.new /var/db/aide/databases/aide.db
       args:
-        creates: /var/lib/aide/aide.db.gz
-        removes: /var/lib/aide/aide.db.new.gz
+        creates: /var/db/aide/databases/aide.db
+        removes: /var/db/aide/databases/aide.db.new
+      changed_when: true
       when:
         - freebsd_cis_remediate | bool
-        - cis_5_3_1_aide.stdout | trim == ''
+        - cis_5_3_1_conf_stat.stat.exists
 
 # ---
 

--- a/tasks/section_5.yml
+++ b/tasks/section_5.yml
@@ -1636,12 +1636,16 @@
       register: cis_5_3_1_conf_stat
       failed_when: false
       check_mode: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
 
     - name: "5.3.1 | REMEDIATE | Warn if aide.conf not found"
       ansible.builtin.debug:
         msg: "WARNING: /usr/local/etc/aide.conf not found — AIDE config fix and database init skipped"
       when:
         - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
         - not cis_5_3_1_conf_stat.stat.exists
 
     - name: "5.3.1 | REMEDIATE | Fix file:// URI scheme in aide.conf database paths"
@@ -1651,6 +1655,7 @@
         replace: '\1'
       when:
         - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
         - cis_5_3_1_conf_stat.stat.exists
 
     - name: "5.3.1 | REMEDIATE | Ensure AIDE database directory exists"
@@ -1662,26 +1667,50 @@
         mode: '0700'
       when:
         - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
+        - cis_5_3_1_conf_stat.stat.exists
+
+    - name: "5.3.1 | REMEDIATE | Stat final AIDE database"
+      ansible.builtin.stat:
+        path: /var/db/aide/databases/aide.db
+      register: cis_5_3_1_db_stat
+      failed_when: false
+      check_mode: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
         - cis_5_3_1_conf_stat.stat.exists
 
     - name: "5.3.1 | REMEDIATE | Initialize AIDE database"
       ansible.builtin.command: /usr/local/bin/aide --init
-      args:
-        creates: /var/db/aide/databases/aide.db.new
       changed_when: true
       when:
         - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
         - cis_5_3_1_conf_stat.stat.exists
+        - not cis_5_3_1_db_stat.stat.exists
+
+    - name: "5.3.1 | REMEDIATE | Stat new AIDE database output"
+      ansible.builtin.stat:
+        path: /var/db/aide/databases/aide.db.new
+      register: cis_5_3_1_db_new_stat
+      failed_when: false
+      check_mode: false
+      when:
+        - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
+        - cis_5_3_1_conf_stat.stat.exists
+        - not cis_5_3_1_db_stat.stat.exists
 
     - name: "5.3.1 | REMEDIATE | Move AIDE database into place"
       ansible.builtin.command: mv /var/db/aide/databases/aide.db.new /var/db/aide/databases/aide.db
-      args:
-        creates: /var/db/aide/databases/aide.db
-        removes: /var/db/aide/databases/aide.db.new
       changed_when: true
       when:
         - freebsd_cis_remediate | bool
+        - cis_5_3_1_aide.stdout | trim == ''
         - cis_5_3_1_conf_stat.stat.exists
+        - not cis_5_3_1_db_stat.stat.exists
+        - cis_5_3_1_db_new_stat.stat.exists
 
 # ---
 


### PR DESCRIPTION
## Summary

Fixes a runtime failure in 5.3.1 AIDE remediation caused by two bugs:

1. **Upstream port bug** — The FreeBSD `security/aide` port ships `/usr/local/etc/aide.conf` with `database=` and `database_out=` lines using `file:///` URI prefixes that the AIDE binary does not support. Running `aide --init` exits rc=17 with `ERROR: unexpected character: ':'`.

2. **Role path bug** — The init and move tasks used `/var/lib/aide/` (a Linux FHS path) and `.gz` suffixed filenames. Neither exist on FreeBSD; the port uses `/var/db/aide/databases/` and plain `.new` / `.db` filenames.

## Why

The benchmark (CIS FreeBSD 14 v1.0.1) itself specifies the wrong Linux paths. The role followed the benchmark and inherited both bugs. This divergence is documented in `docs/DESIGN.md` per the repo's benchmark fidelity policy.

## Changes

- New remediation task: `ansible.builtin.replace` strips `file://` from `database=` and `database_out=` in `aide.conf` before running `--init`
- New `stat` + `debug warn` tasks guard the config patch and all downstream tasks against a missing `aide.conf`
- New task: create `/var/db/aide/databases/` with mode `0700` before init
- Corrected all path references from `/var/lib/aide/*.gz` → `/var/db/aide/databases/aide.db{.new,}`
- Removed stale `.gz` extension (FreeBSD port does not gzip the database)
- `docs/DESIGN.md`: added "Benchmark Fidelity and Known Divergences" section documenting this divergence with verification details

## Validation

- Confirmed against live FreeBSD 14 host with `security/aide` installed
- `grep '^database' /usr/local/etc/aide.conf` → both `database=` and `database_out=` lines affected by `file://` bug
- `aide --init` fails rc=17 before patch; config fix resolves the error
- `ansible-lint --profile production tasks/section_5.yml` → 0 failures
- Pre-commit hooks (detect-secrets, syntax-check, ansible-lint) → all passed

## Risks and Follow-ups

- The `replace` regexp `'^(database(?:_out)?=)file://'` is targeted; it will no-op if a future port release fixes the URI scheme, making it safe to leave in place.
- No unit test target exists for section_5 remediation tasks — this is a known testing gap, not introduced by this PR.
