### PR TITLE
fix: 4.1.1.3 seed root in cron.allow on creation to prevent lockout

### DIFF
--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -148,10 +148,16 @@
                if (cis_4_1_1_3_allow_ok | bool) and (cis_4_1_1_3_deny_ok | bool)
                else 'NON-COMPLIANT: see details above — review /var/cron/allow contents per site policy'] }}"
 
-    - name: "4.1.1.3 | REMEDIATE | Create /var/cron/allow if absent"
-      ansible.builtin.file:
-        path: /var/cron/allow
-        state: touch
+    # Benchmark divergence: the CIS control specifies existence and permissions of
+    # /var/cron/allow but is silent on contents (hence the manual tag — contents
+    # are site policy). Creating an empty file locks out all users including root.
+    # We seed root as a safe operational default. Operators must add additional
+    # authorized users per site policy. An existing file's contents are never modified.
+    - name: "4.1.1.3 | REMEDIATE | Create /var/cron/allow seeded with root if absent"
+      ansible.builtin.copy:
+        dest: /var/cron/allow
+        content: "root\n"
+        force: false
         owner: root
         group: wheel
         mode: '0640'


### PR DESCRIPTION
## Summary

Fixes an operational defect in 4.1.1.3 where creating `/var/cron/allow` from scratch produced an empty file, locking out all users including root from `crontab(1)`.

## Why

On FreeBSD, when `/var/cron/allow` exists, `cron(8)` enforces an explicit allow-list: only users whose names appear in the file may invoke `crontab`. An empty file means nobody — including root — can schedule or modify crontab entries. This caused 5.3.2 remediation to fail (`crontab: you (root) are not allowed to use this program`) after 4.1.1.3 ran.

The CIS benchmark control "Ensure crontab is restricted to authorized users" is silent on file contents — it specifies existence and file permissions only (hence the `manual` tag; contents are site policy). The benchmark does not require excluding root; it requires an allow-list mechanism. Creating an empty file is a role defect, not benchmark compliance.

**Fix:** Replace `ansible.builtin.file: state: touch` with `ansible.builtin.copy: force: false` seeding `root` as the initial entry. The `force: false` flag means an existing file's contents are never overwritten — operators who have already populated the file are not affected. Operators must still add any additional authorized users per site policy.

## Validation

- `ansible-lint --profile production tasks/section_4.yml` → 0 failures
- Pre-commit hooks (detect-secrets, syntax-check, ansible-lint) → all passed
- Verified FreeBSD cron.allow semantics: empty file = no users allowed, root entry required for root crontab access

## Risks and Follow-ups

- Existing hosts where `/var/cron/allow` was already created empty by a previous run of this role will not be remediated automatically (due to `force: false`). Operators should check and add `root` manually on affected hosts, or temporarily add 4.1.1.3 to exceptions, delete the empty file, and re-run.
- No unit test target exists for section_4 remediation tasks — known testing gap, not introduced by this PR.
