### PR TITLE
chore: rename *_exceptions variables and prose to *_exclusions

### DIFF
--- a/.github/agents/principal-freebsd-ansible-security.agent.md
+++ b/.github/agents/principal-freebsd-ansible-security.agent.md
@@ -10,7 +10,7 @@ You are the Principal Security Engineer for the FreeBSD 14 CIS Ansible role.
 - FreeBSD 14 CIS benchmark audit/remediation logic
 - Ansible task safety, idempotence, and deterministic behavior
 - Secret and credential handling across vars, templates, and automation
-- Exception model safety (`freebsd_cis_global_exceptions`, `freebsd_cis_local_exceptions`, `active_exceptions`)
+- Exclusion model safety (`freebsd_cis_global_exclusions`, `freebsd_cis_local_exclusions`, `active_exclusions`)
 
 ## Instructions to Always Apply
 
@@ -30,7 +30,7 @@ You are the Principal Security Engineer for the FreeBSD 14 CIS Ansible role.
 1. Validate trust boundaries and inputs to shell/command tasks.
 2. Verify idempotence (`changed_when`, `failed_when`, and guard conditions).
 3. Confirm remediation only runs when explicitly enabled.
-4. Check exception handling cannot silently bypass unintended controls.
+4. Check exclusion handling cannot silently bypass unintended controls.
 5. Ensure no secrets are committed or rendered into logs/state.
 
 ## Constraints

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Every CIS control is one top-level block. Target pattern (see `docs/DESIGN.md`):
 
 ```yaml
 - name: "<id> | Ensure <description>"
-  when: "'<id>' not in active_exceptions"
+  when: "'<id>' not in active_exclusions"
   tags: [rule_<id>, level1|level2, section_<N>]
   block:
 
@@ -92,13 +92,13 @@ Additional tags are allowed for special cases: `automated`, `manual`.
 
 ---
 
-## Exception Handling
+## Exclusion Handling
 
 Initialized in `tasks/main.yml`:
 ```yaml
-active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
+active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"
 ```
-Every top-level control block has `when: "'<id>' not in active_exceptions"`.
+Every top-level control block has `when: "'<id>' not in active_exclusions"`.
 Skipped controls appear as `skipped` in Ansible output — do not use `ignore_errors`.
 
 ---
@@ -106,7 +106,7 @@ Skipped controls appear as `skipped` in Ansible output — do not use `ignore_er
 ## Defaults vs Vars
 
 - `defaults/main.yml` — operator-tunable settings (`freebsd_cis_remediate`, `freebsd_cis_level`,
-  exception lists, control-specific tunables like `freebsd_cis_tmp_size`). All should have comments.
+  exclusion lists, control-specific tunables like `freebsd_cis_tmp_size`). All should have comments.
 - `vars/main.yml` — internal, non-overridable role metadata (`freebsd_cis_benchmark_version`, etc.).
 - New control-specific tunables go in `defaults/main.yml` under the relevant section header comment.
 
@@ -265,9 +265,9 @@ boundary, not just at merge. Manual `ansible-lint` runs remain optional for earl
 ## File Layout
 
 ```
-defaults/main.yml       # Operator tunables and exception lists
+defaults/main.yml       # Operator tunables and exclusion lists
 vars/main.yml           # Internal role metadata (benchmark name/version)
-tasks/main.yml          # Orchestrator: merge exceptions, import sections
+tasks/main.yml          # Orchestrator: merge exclusions, import sections
 tasks/section_1.yml     # CIS Section 1 — Initial Setup
 tasks/section_2.yml     # CIS Section 2 — Services
 tasks/section_3.yml     # CIS Section 3 — Network

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -65,7 +65,7 @@ If the answer is no — the current wording is unambiguous, the command works, t
 ## Repo-Specific Risk Priorities
 
 - Audit/remediation mode gating errors (`freebsd_cis_remediate`)
-- Exception merge/skip logic errors (`freebsd_cis_global_exceptions`, `freebsd_cis_local_exceptions`, `active_exceptions`)
+- Exclusion merge/skip logic errors (`freebsd_cis_global_exclusions`, `freebsd_cis_local_exclusions`, `active_exclusions`)
 - Non-idempotent Ansible behavior (`changed_when`, `failed_when`, missing guards)
 - Secret exposure risks in automation and IaC
 

--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -24,8 +24,8 @@ applyTo: "**/*.py, **/*.sql, **/*.yaml, **/*.yml, **/*.tf, **/*.tfvars, **/*.aut
 - Remediation logic must run only when both are true:
   - the control is non-compliant
   - `freebsd_cis_remediate | bool`
-- Respect exceptions consistently using `active_exceptions`.
-- Avoid silent bypasses of controls due to broad or malformed exception checks.
+- Respect exclusions consistently using `active_exclusions`.
+- Avoid silent bypasses of controls due to broad or malformed exclusion checks.
 
 ## FreeBSD Hardening Safety
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An Ansible role for auditing and optionally remediating FreeBSD 14 hosts against
 - Audits CIS controls by default — no host state is changed unless explicitly enabled.
 - Marks non-compliant checks as `changed` in Ansible output for easy grep/reporting.
 - Applies remediation only when `freebsd_cis_remediate: true`.
-- Supports layered exception handling for environment-specific deviations.
+- Supports layered exclusion handling for environment-specific deviations.
 - Audit-only mode (`freebsd_cis_remediate: false`) is safe to run on production hosts at any time.
 
 ## Modes
@@ -60,22 +60,22 @@ The role includes pre-flight `stat` checks for optional files and binaries. When
 
 The handler `Resync auditd` runs `/usr/sbin/audit -s` after any change to `/etc/security/audit_control`. This ensures audit configuration changes take effect immediately without a full audit daemon restart.
 
-## Exception Model
+## Exclusion Model
 
-Two lists merge into one active exceptions set used by each control:
+Two lists merge into one active exclusions set used by each control:
 
 ```yaml
-freebsd_cis_global_exceptions: []   # role-level skips
-freebsd_cis_local_exceptions: []    # playbook/host-level skips
+freebsd_cis_global_exclusions: []   # role-level skips
+freebsd_cis_local_exclusions: []    # playbook/host-level skips
 ```
 
 Both variables are intended to be YAML lists of string rule IDs. At play start,
-`tasks/main.yml` validates that the iterated exception values are string rule IDs and
+`tasks/main.yml` validates that the iterated exclusion values are string rule IDs and
 fails with a clear message when non-string elements are present. The effective set is
 then computed:
 
 ```yaml
-active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
+active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"
 ```
 
 Skipped controls appear as `skipped` in Ansible output.
@@ -90,8 +90,8 @@ All operator-tunable variables live in `defaults/main.yml`.
 | --- | --- | --- |
 | `freebsd_cis_remediate` | `false` | Enable remediation. `false` = audit-only. |
 | `freebsd_cis_level` | `1` | CIS profile level (1 or 2). Level 2 enables additional controls. |
-| `freebsd_cis_global_exceptions` | `[]` | Rule IDs to skip at the role level. |
-| `freebsd_cis_local_exceptions` | `[]` | Rule IDs to skip at the playbook or host level. |
+| `freebsd_cis_global_exclusions` | `[]` | Rule IDs to skip at the role level. |
+| `freebsd_cis_local_exclusions` | `[]` | Rule IDs to skip at the playbook or host level. |
 
 ### Section 1 — Initial Setup
 
@@ -163,9 +163,9 @@ bash scripts/syntax-check.sh                              # validate playbook sy
 ## Project Layout
 
 ```bash
-defaults/main.yml       # Operator tunables and exception lists
+defaults/main.yml       # Operator tunables and exclusion lists
 vars/main.yml           # Internal role metadata (benchmark name/version)
-tasks/main.yml          # Orchestrator: merge exceptions, import sections
+tasks/main.yml          # Orchestrator: merge exclusions, import sections
 tasks/section_1.yml     # CIS Section 1 — Initial Setup
 tasks/section_2.yml     # CIS Section 2 — Services
 tasks/section_3.yml     # CIS Section 3 — Network

--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ The handler `Resync auditd` runs `/usr/sbin/audit -s` after any change to `/etc/
 
 ## Exclusion Model
 
+### Breaking Change
+
+This role renamed the skip-list variables from `*_exceptions` to `*_exclusions`.
+If your inventory or playbooks still set `freebsd_cis_global_exceptions` or
+`freebsd_cis_local_exceptions`, rename them to
+`freebsd_cis_global_exclusions` and `freebsd_cis_local_exclusions`.
+The old names are ignored.
+
 Two lists merge into one active exclusions set used by each control:
 
 ```yaml

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,11 +11,11 @@ freebsd_cis_level: 1
 
 # Rule IDs to skip globally (defined at the role level).
 # Example: ["1.1.1.1", "3.2.1"]
-freebsd_cis_global_exceptions: []
+freebsd_cis_global_exclusions: []
 
 # Rule IDs to skip locally (defined at the playbook or host level).
 # Example: ["4.2.19"]
-freebsd_cis_local_exceptions: []
+freebsd_cis_local_exclusions: []
 
 # -------------------------------------------------------------------
 # Section 1 — Initial Setup

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 
 The role is built around a conditional execution pipeline. Each CIS control is processed using the following sequence:
 
-1. **Exception Check**: Determine whether the rule ID exists in the `active_exceptions` list. If present, the rule is skipped (Blue/Cyan).
+1. **Exclusion Check**: Determine whether the rule ID exists in the `active_exclusions` list. If present, the rule is skipped (Blue/Cyan).
 2. **Audit Phase**: Execute a validation step (command, module, or fact-based check). If the system meets the benchmark, return `ok` (Green). If it does not, return `changed` (Yellow).
 3. **Remediation Phase**: If the raw audit signal indicates non-compliance (for example, `result.rc != 0`, `result.rc == 0`, or a mismatched `stdout` value) and `freebsd_cis_remediate` is set to `true`, run the corresponding remediation task.
 
@@ -15,12 +15,12 @@ Notes:
 
 ## Data Merging Strategy
 
-Exception handling is initialized during role setup using a `set_fact` operation:
+Exclusion handling is initialized during role setup using a `set_fact` operation:
 
-- **Global Exceptions**: Defined in `defaults/main.yml`.
-- **Local Exceptions**: Supplied via the playbook or `host_vars`.
+- **Global Exclusions**: Defined in `defaults/main.yml`.
+- **Local Exclusions**: Supplied via the playbook or `host_vars`.
 - **Merged Result**:  
-  `active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"`
+  `active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"`
 
 ## Mode Definitions
 
@@ -35,5 +35,5 @@ Exception handling is initialized during role setup using a `set_fact` operation
 - `defaults/main.yml`: Contains global variables and default accepted states.
 - `vars/main.yml`: Stores internal benchmark-related metadata.
 - `meta/main.yml`: Ansible Galaxy role metadata (platforms, min Ansible version, dependencies).
-- `tasks/main.yml`: Acts as the orchestrator—merging exceptions and importing section task files.
+- `tasks/main.yml`: Acts as the orchestrator—merging exclusions and importing section task files.
 - `tasks/section_N.yml`: One file per CIS section. Each file contains co-located audit and remediation blocks for every control in that section. Audit and remediation logic are grouped together in a single block per control; the `freebsd_cis_remediate` flag gates remediation execution.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -29,7 +29,7 @@ Each CIS control is defined as a block to keep audit and remediation logic group
       when: 
         - cis_1_1_1_mount.rc != 0   # Use .rc directly, not .changed
         - freebsd_cis_remediate | bool
-  when: "'1.1.1' not in active_exceptions"
+  when: "'1.1.1' not in active_exclusions"
   tags: [rule_1.1.1, level1, section_1]
 ```
 
@@ -47,12 +47,12 @@ the same raw signal the audit task used, regardless of how `changed_when` is exp
 Both approaches are semantically equivalent when `changed_when` is set correctly, but `.rc`-based
 conditions are preferred for long-term maintainability in this role.
 
-## Exception Handling Initialization
+## Exclusion Handling Initialization
 
 ```yaml
 - name: "Initialize Compliance Configuration"
   set_fact:
-    active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
+    active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"
 ```
 
 ## Layout Recommendations
@@ -64,14 +64,14 @@ conditions are preferred for long-term maintainability in this role.
 | `ok` | Green | Any | Check passed — system is compliant |
 | `changed` | Yellow | Audit | Check failed — non-compliance detected, no changes made |
 | `changed` | Yellow | Remediation | Check failed — remediation applied successfully |
-| `skipped` | Blue/Cyan | Any | Rule ID is in `active_exceptions` — not evaluated |
+| `skipped` | Blue/Cyan | Any | Rule ID is in `active_exclusions` — not evaluated |
 | `failed` | Red | Any | Unexpected error during audit or remediation task |
 
 ### Variable Naming Conventions
 
 * `freebsd_cis_remediate`: Boolean flag controlling whether remediation is applied (default: false).
-* `freebsd_cis_global_exceptions`: List of rule IDs defined at the role level.
-* `freebsd_cis_local_exceptions`: List of rule IDs defined by the user (playbook or host-level).
+* `freebsd_cis_global_exclusions`: List of rule IDs defined at the role level.
+* `freebsd_cis_local_exclusions`: List of rule IDs defined by the user (playbook or host-level).
 * `cis_<id>_<purpose>`: Internal variables used to store audit/remediation task results for each rule (for example: `cis_1_1_1_1_kld`, `cis_1_1_2_1_1_mount`).
 
 ## Benchmark Fidelity and Known Divergences

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -27,8 +27,8 @@ Each CIS control is defined as a block to keep audit and remediation logic group
         msg: "Applying fix for /tmp partition..."
       # Replace with actual remediation logic
       when: 
-        - cis_1_1_1_mount.rc != 0   # Use .rc directly, not .changed
         - freebsd_cis_remediate | bool
+        - cis_1_1_1_mount.rc != 0   # Use .rc directly, not .changed
   when: "'1.1.1' not in active_exclusions"
   tags: [rule_1.1.1, level1, section_1]
 ```

--- a/docs/PROPOSAL.md
+++ b/docs/PROPOSAL.md
@@ -10,10 +10,10 @@ I have several FreeBSD VPS's and manually maintaining compliance is inefficient 
 A single Ansible Galaxy role that:
 
 1. **Runs audits by default**, using Ansible’s `changed` status to flag non-compliant conditions without modifying the system.
-2. **Allows rule exceptions** through a layered variable structure, enabling environment-specific overrides (e.g., relaxing SSH requirements on a bastion host).
+2. **Allows rule exclusions** through a layered variable structure, enabling environment-specific overrides (e.g., relaxing SSH requirements on a bastion host).
 3. **Performs remediation only when explicitly enabled**, ensuring administrators retain full control over when changes are applied.
 
 ## Expected Outcomes
 - **Visibility:** Immediate insight into the compliance state across all managed FreeBSD systems.
 - **Safety:** Audit mode runs without `--check`, enabling more comprehensive validation than standard check mode typically allows.
-- **Flexibility:** Combined global and local exception handling allows security teams to define baselines while enabling operations teams to override specific rules as needed.
+- **Flexibility:** Combined global and local exclusion handling allows security teams to define baselines while enabling operations teams to override specific rules as needed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,20 +4,20 @@
 - name: "Initialize | Validate exception variable types"
   ansible.builtin.assert:
     that:
-      - (freebsd_cis_global_exceptions | map('type_debug') | unique | difference(['str']) | length) == 0
-      - (freebsd_cis_local_exceptions | map('type_debug') | unique | difference(['str']) | length) == 0
+      - (freebsd_cis_global_exclusions | map('type_debug') | unique | difference(['str']) | length) == 0
+      - (freebsd_cis_local_exclusions | map('type_debug') | unique | difference(['str']) | length) == 0
     fail_msg: >-
-      freebsd_cis_global_exceptions and freebsd_cis_local_exceptions must both be YAML lists
+      freebsd_cis_global_exclusions and freebsd_cis_local_exclusions must both be YAML lists
       containing only string rule IDs. Got container types:
-      global={{ freebsd_cis_global_exceptions | type_debug }},
-      local={{ freebsd_cis_local_exceptions | type_debug }}.
+      global={{ freebsd_cis_global_exclusions | type_debug }},
+      local={{ freebsd_cis_local_exclusions | type_debug }}.
       Element types must all be 'str'; define them like ["1.1.1.1"] and not as dicts,
       integers, or nested lists.
   tags: [always]
 
 - name: "Initialize | Merge exception lists"
   ansible.builtin.set_fact:
-    active_exceptions: "{{ (freebsd_cis_global_exceptions + freebsd_cis_local_exceptions) | unique }}"
+    active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"
   tags: [always]
 
 - name: "Initialize | Warn — freebsd_cis_audit_expire_after is a small size-only value"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # FreeBSD 14 CIS Benchmark v1.0.1 — Task Orchestrator
 
-- name: "Initialize | Validate exception variable types"
+- name: "Initialize | Validate exclusion variable types"
   ansible.builtin.assert:
     that:
       - (freebsd_cis_global_exclusions | map('type_debug') | unique | difference(['str']) | length) == 0
@@ -15,7 +15,7 @@
       integers, or nested lists.
   tags: [always]
 
-- name: "Initialize | Merge exception lists"
+- name: "Initialize | Merge exclusion lists"
   ansible.builtin.set_fact:
     active_exclusions: "{{ (freebsd_cis_global_exclusions + freebsd_cis_local_exclusions) | unique }}"
   tags: [always]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,8 @@
 - name: "Initialize | Validate exclusion variable types"
   ansible.builtin.assert:
     that:
+      - (freebsd_cis_global_exclusions | type_debug) == 'list'
+      - (freebsd_cis_local_exclusions | type_debug) == 'list'
       - (freebsd_cis_global_exclusions | map('type_debug') | unique | difference(['str']) | length) == 0
       - (freebsd_cis_local_exclusions | map('type_debug') | unique | difference(['str']) | length) == 0
     fail_msg: >-

--- a/tasks/section_1.yml
+++ b/tasks/section_1.yml
@@ -9,7 +9,7 @@
 # =============================================================
 
 - name: "1.1.1.1 | Ensure ext2fs kernel module is not available"
-  when: "'1.1.1.1' not in active_exceptions"
+  when: "'1.1.1.1' not in active_exclusions"
   tags: [rule_1.1.1.1, level1, section_1]
   block:
     - name: "1.1.1.1 | AUDIT | Check whether ext2fs module is loaded"
@@ -61,7 +61,7 @@
 # ---
 
 - name: "1.1.1.2 | Ensure msdosfs kernel module is not available"
-  when: "'1.1.1.2' not in active_exceptions"
+  when: "'1.1.1.2' not in active_exclusions"
   tags: [rule_1.1.1.2, level1, section_1]
   block:
     - name: "1.1.1.2 | AUDIT | Check whether msdosfs module is loaded"
@@ -113,7 +113,7 @@
 # ---
 
 - name: "1.1.1.3 | Ensure zfs kernel module is not available"
-  when: "'1.1.1.3' not in active_exceptions"
+  when: "'1.1.1.3' not in active_exclusions"
   tags: [rule_1.1.1.3, level1, section_1]
   block:
     - name: "1.1.1.3 | AUDIT | Check whether zfs module is loaded"
@@ -232,7 +232,7 @@
 # =============================================================
 
 - name: "1.1.2.1.1 | Ensure /tmp is a separate partition"
-  when: "'1.1.2.1.1' not in active_exceptions"
+  when: "'1.1.2.1.1' not in active_exclusions"
   tags: [rule_1.1.2.1.1, level1, section_1]
   block:
     - name: "1.1.2.1.1 | AUDIT | Check if /tmp is a separately mounted filesystem" # noqa: command-instead-of-module risky-shell-pipe
@@ -287,7 +287,7 @@
 # ---
 
 - name: "1.1.2.1.2 | Ensure nosuid option set on /tmp partition"
-  when: "'1.1.2.1.2' not in active_exceptions"
+  when: "'1.1.2.1.2' not in active_exclusions"
   tags: [rule_1.1.2.1.2, level1, section_1]
   block:
     - name: "1.1.2.1.2 | AUDIT | Check /tmp mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -337,7 +337,7 @@
 # ---
 
 - name: "1.1.2.1.3 | Ensure noexec option set on /tmp partition"
-  when: "'1.1.2.1.3' not in active_exceptions"
+  when: "'1.1.2.1.3' not in active_exclusions"
   tags: [rule_1.1.2.1.3, level1, section_1]
   block:
     - name: "1.1.2.1.3 | AUDIT | Check /tmp mount for missing noexec" # noqa: command-instead-of-module risky-shell-pipe
@@ -390,7 +390,7 @@
 
 - name: "1.1.2.2.1 | Ensure separate partition exists for /home"
   when:
-    - "'1.1.2.2.1' not in active_exceptions"
+    - "'1.1.2.2.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_1.1.2.2.1, level2, section_1]
   block:
@@ -411,7 +411,7 @@
 # ---
 
 - name: "1.1.2.2.2 | Ensure nosuid option set on /home partition"
-  when: "'1.1.2.2.2' not in active_exceptions"
+  when: "'1.1.2.2.2' not in active_exclusions"
   tags: [rule_1.1.2.2.2, level1, section_1]
   block:
     - name: "1.1.2.2.2 | AUDIT | Check /home mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -451,7 +451,7 @@
 
 - name: "1.1.2.3.1 | Ensure separate partition exists for /var"
   when:
-    - "'1.1.2.3.1' not in active_exceptions"
+    - "'1.1.2.3.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_1.1.2.3.1, level2, section_1]
   block:
@@ -472,7 +472,7 @@
 # ---
 
 - name: "1.1.2.3.2 | Ensure nosuid option set on /var partition"
-  when: "'1.1.2.3.2' not in active_exceptions"
+  when: "'1.1.2.3.2' not in active_exclusions"
   tags: [rule_1.1.2.3.2, level1, section_1]
   block:
     - name: "1.1.2.3.2 | AUDIT | Check /var mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -512,7 +512,7 @@
 
 - name: "1.1.2.4.1 | Ensure separate partition exists for /var/tmp"
   when:
-    - "'1.1.2.4.1' not in active_exceptions"
+    - "'1.1.2.4.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_1.1.2.4.1, level2, section_1]
   block:
@@ -533,7 +533,7 @@
 # ---
 
 - name: "1.1.2.4.2 | Ensure nosuid option set on /var/tmp partition"
-  when: "'1.1.2.4.2' not in active_exceptions"
+  when: "'1.1.2.4.2' not in active_exclusions"
   tags: [rule_1.1.2.4.2, level1, section_1]
   block:
     - name: "1.1.2.4.2 | AUDIT | Check /var/tmp mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -570,7 +570,7 @@
 # ---
 
 - name: "1.1.2.4.3 | Ensure noexec option set on /var/tmp partition"
-  when: "'1.1.2.4.3' not in active_exceptions"
+  when: "'1.1.2.4.3' not in active_exclusions"
   tags: [rule_1.1.2.4.3, level1, section_1]
   block:
     - name: "1.1.2.4.3 | AUDIT | Check /var/tmp mount for missing noexec" # noqa: command-instead-of-module risky-shell-pipe
@@ -610,7 +610,7 @@
 
 - name: "1.1.2.5.1 | Ensure separate partition exists for /var/log"
   when:
-    - "'1.1.2.5.1' not in active_exceptions"
+    - "'1.1.2.5.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_1.1.2.5.1, level2, section_1]
   block:
@@ -631,7 +631,7 @@
 # ---
 
 - name: "1.1.2.5.2 | Ensure nosuid option set on /var/log partition"
-  when: "'1.1.2.5.2' not in active_exceptions"
+  when: "'1.1.2.5.2' not in active_exclusions"
   tags: [rule_1.1.2.5.2, level1, section_1]
   block:
     - name: "1.1.2.5.2 | AUDIT | Check /var/log mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -668,7 +668,7 @@
 # ---
 
 - name: "1.1.2.5.3 | Ensure noexec option set on /var/log partition"
-  when: "'1.1.2.5.3' not in active_exceptions"
+  when: "'1.1.2.5.3' not in active_exclusions"
   tags: [rule_1.1.2.5.3, level1, section_1]
   block:
     - name: "1.1.2.5.3 | AUDIT | Check /var/log mount for missing noexec" # noqa: command-instead-of-module risky-shell-pipe
@@ -708,7 +708,7 @@
 
 - name: "1.1.2.6.1 | Ensure separate partition exists for /var/audit"
   when:
-    - "'1.1.2.6.1' not in active_exceptions"
+    - "'1.1.2.6.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_1.1.2.6.1, level2, section_1]
   block:
@@ -729,7 +729,7 @@
 # ---
 
 - name: "1.1.2.6.2 | Ensure nosuid option set on /var/audit partition"
-  when: "'1.1.2.6.2' not in active_exceptions"
+  when: "'1.1.2.6.2' not in active_exclusions"
   tags: [rule_1.1.2.6.2, level1, section_1]
   block:
     - name: "1.1.2.6.2 | AUDIT | Check /var/audit mount for missing nosuid" # noqa: command-instead-of-module risky-shell-pipe
@@ -766,7 +766,7 @@
 # ---
 
 - name: "1.1.2.6.3 | Ensure noexec option set on /var/audit partition"
-  when: "'1.1.2.6.3' not in active_exceptions"
+  when: "'1.1.2.6.3' not in active_exclusions"
   tags: [rule_1.1.2.6.3, level1, section_1]
   block:
     - name: "1.1.2.6.3 | AUDIT | Check /var/audit mount for missing noexec" # noqa: command-instead-of-module risky-shell-pipe
@@ -805,7 +805,7 @@
 # =============================================================
 
 - name: "1.2.1 | Ensure update server certificate key fingerprints are configured"
-  when: "'1.2.1' not in active_exceptions"
+  when: "'1.2.1' not in active_exclusions"
   tags: [rule_1.2.1, level1, section_1]
   block:
     - name: "1.2.1 | AUDIT | Read KeyPrint from freebsd-update.conf"
@@ -837,7 +837,7 @@
 # ---
 
 - name: "1.2.2 | Ensure package manager repositories are configured"
-  when: "'1.2.2' not in active_exceptions"
+  when: "'1.2.2' not in active_exclusions"
   tags: [rule_1.2.2, level1, section_1]
   block:
     # Guard against the pkg bootstrap stub hanging: the stub at /usr/sbin/pkg
@@ -877,7 +877,7 @@
 # ---
 
 - name: "1.2.3 | Ensure updates, patches, and additional security software are installed"
-  when: "'1.2.3' not in active_exceptions"
+  when: "'1.2.3' not in active_exclusions"
   tags: [rule_1.2.3, level1, section_1]
   block:
     - name: "1.2.3 | AUDIT | Check for pending base system updates"
@@ -939,7 +939,7 @@
 # =============================================================
 
 - name: "1.3.1 | Ensure bootloader password is set"
-  when: "'1.3.1' not in active_exceptions"
+  when: "'1.3.1' not in active_exclusions"
   tags: [rule_1.3.1, level1, section_1]
   block:
     - name: "1.3.1 | AUDIT | Check for bootloader password in loader.conf"
@@ -984,7 +984,7 @@
 # ---
 
 - name: "1.3.2 | Ensure permissions on bootloader config are configured"
-  when: "'1.3.2' not in active_exceptions"
+  when: "'1.3.2' not in active_exclusions"
   tags: [rule_1.3.2, level1, section_1]
   block:
     - name: "1.3.2 | AUDIT | Check /boot/loader.conf permissions"
@@ -1032,7 +1032,7 @@
 # =============================================================
 
 - name: "1.4.1 | Ensure address space layout randomization (ASLR) is enabled"
-  when: "'1.4.1' not in active_exceptions"
+  when: "'1.4.1' not in active_exclusions"
   tags: [rule_1.4.1, level1, section_1]
   block:
     - name: "1.4.1 | AUDIT | Read kern.elf64.aslr.enable sysctl"
@@ -1071,7 +1071,7 @@
 # ---
 
 - name: "1.4.2 | Ensure core dump backtraces are disabled"
-  when: "'1.4.2' not in active_exceptions"
+  when: "'1.4.2' not in active_exclusions"
   tags: [rule_1.4.2, level1, section_1]
   block:
     - name: "1.4.2 | AUDIT | Check savecore_enable sysrc value"
@@ -1106,7 +1106,7 @@
 # ---
 
 - name: "1.4.3 | Ensure core dump storage is disabled"
-  when: "'1.4.3' not in active_exceptions"
+  when: "'1.4.3' not in active_exclusions"
   tags: [rule_1.4.3, level1, section_1]
   block:
     - name: "1.4.3 | AUDIT | Check dumpdev sysrc value"
@@ -1135,7 +1135,7 @@
 # =============================================================
 
 - name: "1.6.1 | Ensure message of the day is configured properly"
-  when: "'1.6.1' not in active_exceptions"
+  when: "'1.6.1' not in active_exclusions"
   tags: [rule_1.6.1, level1, section_1]
   block:
     - name: "1.6.1 | AUDIT | Check /etc/motd for OS version disclosure"
@@ -1175,7 +1175,7 @@
 # ---
 
 - name: "1.6.2 | Ensure local login warning banner is configured properly"
-  when: "'1.6.2' not in active_exceptions"
+  when: "'1.6.2' not in active_exclusions"
   tags: [rule_1.6.2, level1, section_1]
   block:
     - name: "1.6.2 | AUDIT | Check /etc/issue for OS version disclosure"
@@ -1207,7 +1207,7 @@
 # ---
 
 - name: "1.6.3 | Ensure remote login warning banner is configured properly"
-  when: "'1.6.3' not in active_exceptions"
+  when: "'1.6.3' not in active_exclusions"
   tags: [rule_1.6.3, level1, section_1]
   block:
     - name: "1.6.3 | AUDIT | Check /etc/issue.net for OS version disclosure"
@@ -1239,7 +1239,7 @@
 # ---
 
 - name: "1.6.4 | Ensure access to /etc/motd is configured"
-  when: "'1.6.4' not in active_exceptions"
+  when: "'1.6.4' not in active_exclusions"
   tags: [rule_1.6.4, level1, section_1]
   block:
     - name: "1.6.4 | AUDIT | Stat /etc/motd"
@@ -1275,7 +1275,7 @@
 # ---
 
 - name: "1.6.5 | Ensure access to /etc/issue is configured"
-  when: "'1.6.5' not in active_exceptions"
+  when: "'1.6.5' not in active_exclusions"
   tags: [rule_1.6.5, level1, section_1]
   block:
     - name: "1.6.5 | AUDIT | Stat /etc/issue"

--- a/tasks/section_2.yml
+++ b/tasks/section_2.yml
@@ -9,7 +9,7 @@
 # =============================================================
 
 - name: "2.1.1 | Ensure time synchronization is in use"
-  when: "'2.1.1' not in active_exceptions"
+  when: "'2.1.1' not in active_exclusions"
   tags: [rule_2.1.1, level1, section_2]
   block:
     - name: "2.1.1 | AUDIT | Check ntpd_enable rc.conf setting"
@@ -60,7 +60,7 @@
 # ---
 
 - name: "2.2.1 | Ensure autofs services are not in use"
-  when: "'2.2.1' not in active_exceptions"
+  when: "'2.2.1' not in active_exclusions"
   tags: [rule_2.2.1, level1, section_2]
   block:
     - name: "2.2.1 | AUDIT | Check autofs_enable rc.conf setting"
@@ -97,7 +97,7 @@
 # ---
 
 - name: "2.2.2 | Ensure ftp server services are not in use"
-  when: "'2.2.2' not in active_exceptions"
+  when: "'2.2.2' not in active_exclusions"
   tags: [rule_2.2.2, level1, section_2]
   block:
     - name: "2.2.2 | AUDIT | Check if ftpd is enabled through inetd"
@@ -153,7 +153,7 @@
 # ---
 
 - name: "2.2.3 | Ensure message access server services are not in use"
-  when: "'2.2.3' not in active_exceptions"
+  when: "'2.2.3' not in active_exclusions"
   tags: [rule_2.2.3, level1, section_2]
   block:
     - name: "2.2.3 | AUDIT | Check if dovecot package is installed"
@@ -216,7 +216,7 @@
 # ---
 
 - name: "2.2.4 | Ensure network file system services are not in use"
-  when: "'2.2.4' not in active_exceptions"
+  when: "'2.2.4' not in active_exclusions"
   tags: [rule_2.2.4, level1, section_2]
   block:
     - name: "2.2.4 | AUDIT | Check nfs_server_enable rc.conf setting"
@@ -253,7 +253,7 @@
 # ---
 
 - name: "2.2.5 | Ensure nis server services are not in use"
-  when: "'2.2.5' not in active_exceptions"
+  when: "'2.2.5' not in active_exclusions"
   tags: [rule_2.2.5, level1, section_2]
   block:
     - name: "2.2.5 | AUDIT | Check nis_server_enable rc.conf setting"
@@ -290,7 +290,7 @@
 # ---
 
 - name: "2.2.6 | Ensure rpcbind services are not in use"
-  when: "'2.2.6' not in active_exceptions"
+  when: "'2.2.6' not in active_exclusions"
   tags: [rule_2.2.6, level1, section_2]
   block:
     - name: "2.2.6 | AUDIT | Check rpcbind_enable rc.conf setting"
@@ -327,7 +327,7 @@
 # ---
 
 - name: "2.2.7 | Ensure snmp services are not in use"
-  when: "'2.2.7' not in active_exceptions"
+  when: "'2.2.7' not in active_exclusions"
   tags: [rule_2.2.7, level1, section_2]
   block:
     - name: "2.2.7 | AUDIT | Check if net-snmp package is installed"
@@ -363,7 +363,7 @@
 # ---
 
 - name: "2.2.8 | Ensure telnet server services are not in use"
-  when: "'2.2.8' not in active_exceptions"
+  when: "'2.2.8' not in active_exclusions"
   tags: [rule_2.2.8, level1, section_2]
   block:
     - name: "2.2.8 | AUDIT | Check if freebsd-telnetd package is installed"
@@ -419,7 +419,7 @@
 # ---
 
 - name: "2.2.9 | Ensure tftp server services are not in use"
-  when: "'2.2.9' not in active_exceptions"
+  when: "'2.2.9' not in active_exclusions"
   tags: [rule_2.2.9, level1, section_2]
   block:
     - name: "2.2.9 | AUDIT | Check if tftp is enabled via inetd"
@@ -457,7 +457,7 @@
 # ---
 
 - name: "2.2.10 | Ensure web proxy server services are not in use"
-  when: "'2.2.10' not in active_exceptions"
+  when: "'2.2.10' not in active_exclusions"
   tags: [rule_2.2.10, level1, section_2]
   block:
     - name: "2.2.10 | AUDIT | Check if squid package is installed"
@@ -493,7 +493,7 @@
 # ---
 
 - name: "2.2.11 | Ensure mail transfer agents are configured for local-only mode"
-  when: "'2.2.11' not in active_exceptions"
+  when: "'2.2.11' not in active_exclusions"
   tags: [rule_2.2.11, level1, section_2, automated]
   block:
     - name: "2.2.11 | AUDIT | List all listening sockets"
@@ -536,7 +536,7 @@
 # ---
 
 - name: "2.2.12 | Ensure only approved services are listening on a network interface"
-  when: "'2.2.12' not in active_exceptions"
+  when: "'2.2.12' not in active_exclusions"
   tags: [rule_2.2.12, level1, section_2, manual]
   block:
     - name: "2.2.12 | AUDIT | List all listening network sockets"

--- a/tasks/section_3.yml
+++ b/tasks/section_3.yml
@@ -9,7 +9,7 @@
 # =============================================================
 
 - name: "3.1.1 | Ensure IPv6 status is identified"
-  when: "'3.1.1' not in active_exceptions"
+  when: "'3.1.1' not in active_exclusions"
   tags: [rule_3.1.1, level1, section_3]
   block:
     - name: "3.1.1 | AUDIT | Check kern.features.inet6 sysctl"
@@ -33,7 +33,7 @@
 
 - name: "3.2.1 | Ensure sctp kernel module is not available"
   when:
-    - "'3.2.1' not in active_exceptions"
+    - "'3.2.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_3.2.1, level2, section_3]
   block:
@@ -88,7 +88,7 @@
 # =============================================================
 
 - name: "3.3.1 | Ensure ip forwarding is disabled"
-  when: "'3.3.1' not in active_exceptions"
+  when: "'3.3.1' not in active_exclusions"
   tags: [rule_3.3.1, level1, section_3]
   block:
     - name: "3.3.1 | AUDIT | Check net.inet.ip.forwarding"
@@ -199,7 +199,7 @@
 # ---
 
 - name: "3.3.2 | Ensure packet redirect sending is disabled"
-  when: "'3.3.2' not in active_exceptions"
+  when: "'3.3.2' not in active_exclusions"
   tags: [rule_3.3.2, level1, section_3]
   block:
     - name: "3.3.2 | AUDIT | Check net.inet.ip.redirect"
@@ -270,7 +270,7 @@
 # ---
 
 - name: "3.3.3 | Ensure broadcast and multicast ICMP requests are ignored"
-  when: "'3.3.3' not in active_exceptions"
+  when: "'3.3.3' not in active_exclusions"
   tags: [rule_3.3.3, level1, section_3]
   block:
     - name: "3.3.3 | AUDIT | Check net.inet.icmp.bmcastecho"
@@ -341,7 +341,7 @@
 # ---
 
 - name: "3.3.4 | Ensure ICMP redirects are not accepted"
-  when: "'3.3.4' not in active_exceptions"
+  when: "'3.3.4' not in active_exclusions"
   tags: [rule_3.3.4, level1, section_3]
   block:
     - name: "3.3.4 | AUDIT | Check net.inet.icmp.drop_redirect"
@@ -412,7 +412,7 @@
 # ---
 
 - name: "3.3.5 | Ensure source routed packets are not accepted"
-  when: "'3.3.5' not in active_exceptions"
+  when: "'3.3.5' not in active_exclusions"
   tags: [rule_3.3.5, level1, section_3]
   block:
     - name: "3.3.5 | AUDIT | Check net.inet.ip.accept_sourceroute"
@@ -452,7 +452,7 @@
 # ---
 
 - name: "3.3.6 | Ensure TCP SYN cookies is enabled"
-  when: "'3.3.6' not in active_exceptions"
+  when: "'3.3.6' not in active_exclusions"
   tags: [rule_3.3.6, level1, section_3]
   block:
     - name: "3.3.6 | AUDIT | Check net.inet.tcp.syncookies"
@@ -492,7 +492,7 @@
 # ---
 
 - name: "3.3.7 | Ensure IPv6 router advertisements are not accepted"
-  when: "'3.3.7' not in active_exceptions"
+  when: "'3.3.7' not in active_exclusions"
   tags: [rule_3.3.7, level1, section_3]
   block:
     - name: "3.3.7 | AUDIT | Check net.inet6.ip6.accept_rtadv"
@@ -535,7 +535,7 @@
 # =============================================================
 
 - name: "3.4.1.1 | Ensure ipfw is enabled and configured"
-  when: "'3.4.1.1' not in active_exceptions"
+  when: "'3.4.1.1' not in active_exclusions"
   tags: [rule_3.4.1.1, level1, section_3]
   block:
     - name: "3.4.1.1 | AUDIT | Check firewall_enable rc.conf setting"
@@ -569,7 +569,7 @@
 # ---
 
 - name: "3.4.1.2 | Ensure a single firewall utility is in use"
-  when: "'3.4.1.2' not in active_exceptions"
+  when: "'3.4.1.2' not in active_exclusions"
   tags: [rule_3.4.1.2, level1, section_3]
   block:
     - name: "3.4.1.2 | AUDIT | Check firewall_enable (ipfw)"

--- a/tasks/section_4.yml
+++ b/tasks/section_4.yml
@@ -11,7 +11,7 @@
 # ---
 
 - name: "4.1.1.1 | Ensure permissions on /etc/crontab are configured"
-  when: "'4.1.1.1' not in active_exceptions"
+  when: "'4.1.1.1' not in active_exclusions"
   tags: [rule_4.1.1.1, level1, section_4, automated]
   block:
 
@@ -56,7 +56,7 @@
 # ---
 
 - name: "4.1.1.2 | Ensure permissions on /etc/cron.d are configured"
-  when: "'4.1.1.2' not in active_exceptions"
+  when: "'4.1.1.2' not in active_exclusions"
   tags: [rule_4.1.1.2, level1, section_4, automated]
   block:
 
@@ -101,7 +101,7 @@
 # ---
 
 - name: "4.1.1.3 | Ensure crontab is restricted to authorized users"
-  when: "'4.1.1.3' not in active_exceptions"
+  when: "'4.1.1.3' not in active_exclusions"
   tags: [rule_4.1.1.3, level1, section_4, manual]
   block:
 
@@ -190,7 +190,7 @@
 # ---
 
 - name: "4.1.2.1 | Ensure at is restricted to authorized users"
-  when: "'4.1.2.1' not in active_exceptions"
+  when: "'4.1.2.1' not in active_exclusions"
   tags: [rule_4.1.2.1, level1, section_4, manual]
   block:
 
@@ -277,24 +277,24 @@
 
 - name: "4.2 | GATHER | Query sshd effective configuration via sshd -T"
   when: >-
-    ('4.2.4' not in active_exceptions) or
-    ('4.2.5' not in active_exceptions) or
-    ('4.2.6' not in active_exceptions) or
-    ('4.2.7' not in active_exceptions) or
-    ('4.2.8' not in active_exceptions) or
-    ('4.2.9' not in active_exceptions) or
-    ('4.2.10' not in active_exceptions) or
-    ('4.2.11' not in active_exceptions) or
-    ('4.2.12' not in active_exceptions) or
-    ('4.2.13' not in active_exceptions) or
-    ('4.2.14' not in active_exceptions) or
-    ('4.2.15' not in active_exceptions) or
-    ('4.2.16' not in active_exceptions) or
-    ('4.2.17' not in active_exceptions) or
-    ('4.2.18' not in active_exceptions) or
-    ('4.2.19' not in active_exceptions) or
-    ('4.2.20' not in active_exceptions) or
-    ('4.2.21' not in active_exceptions)
+    ('4.2.4' not in active_exclusions) or
+    ('4.2.5' not in active_exclusions) or
+    ('4.2.6' not in active_exclusions) or
+    ('4.2.7' not in active_exclusions) or
+    ('4.2.8' not in active_exclusions) or
+    ('4.2.9' not in active_exclusions) or
+    ('4.2.10' not in active_exclusions) or
+    ('4.2.11' not in active_exclusions) or
+    ('4.2.12' not in active_exclusions) or
+    ('4.2.13' not in active_exclusions) or
+    ('4.2.14' not in active_exclusions) or
+    ('4.2.15' not in active_exclusions) or
+    ('4.2.16' not in active_exclusions) or
+    ('4.2.17' not in active_exclusions) or
+    ('4.2.18' not in active_exclusions) or
+    ('4.2.19' not in active_exclusions) or
+    ('4.2.20' not in active_exclusions) or
+    ('4.2.21' not in active_exclusions)
   tags: [rule_4.2.4, rule_4.2.5, rule_4.2.6, rule_4.2.7, rule_4.2.8, rule_4.2.9,
          rule_4.2.10, rule_4.2.11, rule_4.2.12, rule_4.2.13, rule_4.2.14, rule_4.2.15,
          rule_4.2.16, rule_4.2.17, rule_4.2.18, rule_4.2.19, rule_4.2.20, rule_4.2.21,
@@ -318,24 +318,24 @@
 
 - name: "4.2 | GATHER | Report sshd -T query status"
   when: >-
-    ('4.2.4' not in active_exceptions) or
-    ('4.2.5' not in active_exceptions) or
-    ('4.2.6' not in active_exceptions) or
-    ('4.2.7' not in active_exceptions) or
-    ('4.2.8' not in active_exceptions) or
-    ('4.2.9' not in active_exceptions) or
-    ('4.2.10' not in active_exceptions) or
-    ('4.2.11' not in active_exceptions) or
-    ('4.2.12' not in active_exceptions) or
-    ('4.2.13' not in active_exceptions) or
-    ('4.2.14' not in active_exceptions) or
-    ('4.2.15' not in active_exceptions) or
-    ('4.2.16' not in active_exceptions) or
-    ('4.2.17' not in active_exceptions) or
-    ('4.2.18' not in active_exceptions) or
-    ('4.2.19' not in active_exceptions) or
-    ('4.2.20' not in active_exceptions) or
-    ('4.2.21' not in active_exceptions)
+    ('4.2.4' not in active_exclusions) or
+    ('4.2.5' not in active_exclusions) or
+    ('4.2.6' not in active_exclusions) or
+    ('4.2.7' not in active_exclusions) or
+    ('4.2.8' not in active_exclusions) or
+    ('4.2.9' not in active_exclusions) or
+    ('4.2.10' not in active_exclusions) or
+    ('4.2.11' not in active_exclusions) or
+    ('4.2.12' not in active_exclusions) or
+    ('4.2.13' not in active_exclusions) or
+    ('4.2.14' not in active_exclusions) or
+    ('4.2.15' not in active_exclusions) or
+    ('4.2.16' not in active_exclusions) or
+    ('4.2.17' not in active_exclusions) or
+    ('4.2.18' not in active_exclusions) or
+    ('4.2.19' not in active_exclusions) or
+    ('4.2.20' not in active_exclusions) or
+    ('4.2.21' not in active_exclusions)
   tags: [rule_4.2.4, rule_4.2.5, rule_4.2.6, rule_4.2.7, rule_4.2.8, rule_4.2.9,
          rule_4.2.10, rule_4.2.11, rule_4.2.12, rule_4.2.13, rule_4.2.14, rule_4.2.15,
          rule_4.2.16, rule_4.2.17, rule_4.2.18, rule_4.2.19, rule_4.2.20, rule_4.2.21,
@@ -369,7 +369,7 @@
 # ---
 
 - name: "4.2.1 | Ensure permissions on /etc/ssh/sshd_config are configured"
-  when: "'4.2.1' not in active_exceptions"
+  when: "'4.2.1' not in active_exclusions"
   tags: [rule_4.2.1, level1, section_4]
   block:
 
@@ -414,7 +414,7 @@
 # ---
 
 - name: "4.2.2 | Ensure permissions on SSH private host key files are configured"
-  when: "'4.2.2' not in active_exceptions"
+  when: "'4.2.2' not in active_exclusions"
   tags: [rule_4.2.2, level1, section_4]
   block:
 
@@ -509,7 +509,7 @@
 # ---
 
 - name: "4.2.3 | Ensure permissions on SSH public host key files are configured"
-  when: "'4.2.3' not in active_exceptions"
+  when: "'4.2.3' not in active_exclusions"
   tags: [rule_4.2.3, level1, section_4]
   block:
 
@@ -606,7 +606,7 @@
 # ---
 
 - name: "4.2.4 | Ensure sshd access is configured"
-  when: "'4.2.4' not in active_exceptions"
+  when: "'4.2.4' not in active_exclusions"
   tags: [rule_4.2.4, level1, section_4, manual]
   block:
 
@@ -708,7 +708,7 @@
 # ---
 
 - name: "4.2.5 | Ensure sshd Banner is configured"
-  when: "'4.2.5' not in active_exceptions"
+  when: "'4.2.5' not in active_exclusions"
   tags: [rule_4.2.5, level1, section_4, manual]
   block:
 
@@ -749,7 +749,7 @@
 # ---
 
 - name: "4.2.6 | Ensure sshd Ciphers are configured"
-  when: "'4.2.6' not in active_exceptions"
+  when: "'4.2.6' not in active_exclusions"
   tags: [rule_4.2.6, level1, section_4, manual]
   block:
 
@@ -798,7 +798,7 @@
 # ---
 
 - name: "4.2.7 | Ensure sshd ClientAliveInterval and ClientAliveCountMax are configured"
-  when: "'4.2.7' not in active_exceptions"
+  when: "'4.2.7' not in active_exclusions"
   tags: [rule_4.2.7, level1, section_4, manual]
   block:
 
@@ -863,7 +863,7 @@
 # ---
 
 - name: "4.2.8 | Ensure sshd DisableForwarding is enabled"
-  when: "'4.2.8' not in active_exceptions"
+  when: "'4.2.8' not in active_exclusions"
   tags: [rule_4.2.8, level1, section_4, manual]
   block:
 
@@ -903,7 +903,7 @@
 # ---
 
 - name: "4.2.9 | Ensure sshd HostbasedAuthentication is disabled"
-  when: "'4.2.9' not in active_exceptions"
+  when: "'4.2.9' not in active_exclusions"
   tags: [rule_4.2.9, level1, section_4, manual]
   block:
 
@@ -943,7 +943,7 @@
 # ---
 
 - name: "4.2.10 | Ensure sshd IgnoreRhosts is enabled"
-  when: "'4.2.10' not in active_exceptions"
+  when: "'4.2.10' not in active_exclusions"
   tags: [rule_4.2.10, level1, section_4, manual]
   block:
 
@@ -983,7 +983,7 @@
 # ---
 
 - name: "4.2.11 | Ensure sshd KexAlgorithms is configured"
-  when: "'4.2.11' not in active_exceptions"
+  when: "'4.2.11' not in active_exclusions"
   tags: [rule_4.2.11, level1, section_4, manual]
   block:
 
@@ -1032,7 +1032,7 @@
 # ---
 
 - name: "4.2.12 | Ensure sshd LoginGraceTime is configured"
-  when: "'4.2.12' not in active_exceptions"
+  when: "'4.2.12' not in active_exclusions"
   tags: [rule_4.2.12, level1, section_4, manual]
   block:
 
@@ -1073,7 +1073,7 @@
 # ---
 
 - name: "4.2.13 | Ensure sshd LogLevel is configured"
-  when: "'4.2.13' not in active_exceptions"
+  when: "'4.2.13' not in active_exclusions"
   tags: [rule_4.2.13, level1, section_4, manual]
   block:
 
@@ -1113,7 +1113,7 @@
 # ---
 
 - name: "4.2.14 | Ensure sshd MACs are configured"
-  when: "'4.2.14' not in active_exceptions"
+  when: "'4.2.14' not in active_exclusions"
   tags: [rule_4.2.14, level1, section_4, manual]
   block:
 
@@ -1162,7 +1162,7 @@
 # ---
 
 - name: "4.2.15 | Ensure sshd MaxAuthTries is configured"
-  when: "'4.2.15' not in active_exceptions"
+  when: "'4.2.15' not in active_exclusions"
   tags: [rule_4.2.15, level1, section_4, manual]
   block:
 
@@ -1202,7 +1202,7 @@
 # ---
 
 - name: "4.2.16 | Ensure sshd MaxSessions is configured"
-  when: "'4.2.16' not in active_exceptions"
+  when: "'4.2.16' not in active_exclusions"
   tags: [rule_4.2.16, level1, section_4, manual]
   block:
 
@@ -1242,7 +1242,7 @@
 # ---
 
 - name: "4.2.17 | Ensure sshd MaxStartups is configured"
-  when: "'4.2.17' not in active_exceptions"
+  when: "'4.2.17' not in active_exclusions"
   tags: [rule_4.2.17, level1, section_4, manual]
   block:
 
@@ -1298,7 +1298,7 @@
 # ---
 
 - name: "4.2.18 | Ensure sshd PermitEmptyPasswords is disabled"
-  when: "'4.2.18' not in active_exceptions"
+  when: "'4.2.18' not in active_exclusions"
   tags: [rule_4.2.18, level1, section_4, manual]
   block:
 
@@ -1338,7 +1338,7 @@
 # ---
 
 - name: "4.2.19 | Ensure sshd PermitRootLogin is disabled"
-  when: "'4.2.19' not in active_exceptions"
+  when: "'4.2.19' not in active_exclusions"
   tags: [rule_4.2.19, level1, section_4, manual]
   block:
 
@@ -1378,7 +1378,7 @@
 # ---
 
 - name: "4.2.20 | Ensure sshd PermitUserEnvironment is disabled"
-  when: "'4.2.20' not in active_exceptions"
+  when: "'4.2.20' not in active_exclusions"
   tags: [rule_4.2.20, level1, section_4, automated]
   block:
 
@@ -1418,7 +1418,7 @@
 # ---
 
 - name: "4.2.21 | Ensure sshd UsePAM is enabled"
-  when: "'4.2.21' not in active_exceptions"
+  when: "'4.2.21' not in active_exclusions"
   tags: [rule_4.2.21, level1, section_4, automated]
   block:
 
@@ -1462,7 +1462,7 @@
 # ---
 
 - name: "4.3.1 | Ensure sudo is installed"
-  when: "'4.3.1' not in active_exceptions"
+  when: "'4.3.1' not in active_exclusions"
   tags: [rule_4.3.1, level1, section_4, manual]
   block:
 
@@ -1491,7 +1491,7 @@
 # ---
 
 - name: "4.3.2 | Ensure sudo commands use pty"
-  when: "'4.3.2' not in active_exceptions"
+  when: "'4.3.2' not in active_exclusions"
   tags: [rule_4.3.2, level1, section_4, automated]
   block:
 
@@ -1524,7 +1524,7 @@
 # ---
 
 - name: "4.3.3 | Ensure sudo log file exists"
-  when: "'4.3.3' not in active_exceptions"
+  when: "'4.3.3' not in active_exclusions"
   tags: [rule_4.3.3, level1, section_4, manual]
   block:
 
@@ -1558,7 +1558,7 @@
 
 - name: "4.3.4 | Ensure users must provide password for escalation"
   when:
-    - "'4.3.4' not in active_exceptions"
+    - "'4.3.4' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_4.3.4, level2, section_4, manual]
   block:
@@ -1610,7 +1610,7 @@
 # ---
 
 - name: "4.3.5 | Ensure re-authentication for privilege escalation is not disabled globally"
-  when: "'4.3.5' not in active_exceptions"
+  when: "'4.3.5' not in active_exclusions"
   tags: [rule_4.3.5, level1, section_4, manual]
   block:
 
@@ -1661,7 +1661,7 @@
 # ---
 
 - name: "4.3.6 | Ensure sudo authentication timeout is configured correctly"
-  when: "'4.3.6' not in active_exceptions"
+  when: "'4.3.6' not in active_exclusions"
   tags: [rule_4.3.6, level1, section_4, manual]
   block:
 
@@ -1707,7 +1707,7 @@
 # ---
 
 - name: "4.3.7 | Ensure access to the su command is restricted"
-  when: "'4.3.7' not in active_exceptions"
+  when: "'4.3.7' not in active_exclusions"
   tags: [rule_4.3.7, level1, section_4, manual]
   block:
 
@@ -1736,7 +1736,7 @@
 # ---
 
 - name: "4.4.1.1.1 | Ensure password length is configured"
-  when: "'4.4.1.1.1' not in active_exceptions"
+  when: "'4.4.1.1.1' not in active_exclusions"
   tags: [rule_4.4.1.1.1, level1, section_4, manual]
   block:
 
@@ -1784,7 +1784,7 @@
 # ---
 
 - name: "4.4.1.1.2 | Ensure password quality is enforced for the root user"
-  when: "'4.4.1.1.2' not in active_exceptions"
+  when: "'4.4.1.1.2' not in active_exclusions"
   tags: [rule_4.4.1.1.2, level1, section_4, manual]
   block:
 
@@ -1815,7 +1815,7 @@
 # ---
 
 - name: "4.4.1.2.1 | Ensure pam_unix does not include nullok"
-  when: "'4.4.1.2.1' not in active_exceptions"
+  when: "'4.4.1.2.1' not in active_exclusions"
   tags: [rule_4.4.1.2.1, level1, section_4, manual]
   block:
 
@@ -1855,7 +1855,7 @@
 # ---
 
 - name: "4.5.1.1 | Ensure strong password hashing algorithm is configured"  # pragma: allowlist secret
-  when: "'4.5.1.1' not in active_exceptions"
+  when: "'4.5.1.1' not in active_exclusions"
   tags: [rule_4.5.1.1, level1, section_4, manual]
   block:
 
@@ -1894,7 +1894,7 @@
 # ---
 
 - name: "4.5.1.2 | Ensure password expiration is 365 days or less"
-  when: "'4.5.1.2' not in active_exceptions"
+  when: "'4.5.1.2' not in active_exclusions"
   tags: [rule_4.5.1.2, level1, section_4, automated]
   block:
 
@@ -1975,7 +1975,7 @@
 # ---
 
 - name: "4.5.1.3 | Ensure password expiration warning days is 7 or more"
-  when: "'4.5.1.3' not in active_exceptions"
+  when: "'4.5.1.3' not in active_exclusions"
   tags: [rule_4.5.1.3, level1, section_4, manual]
   block:
 
@@ -2027,7 +2027,7 @@
 # ---
 
 - name: "4.5.2.1 | Ensure default group for the root account is GID 0"
-  when: "'4.5.2.1' not in active_exceptions"
+  when: "'4.5.2.1' not in active_exclusions"
   tags: [rule_4.5.2.1, level1, section_4, manual]
   block:
 
@@ -2060,7 +2060,7 @@
 # ---
 
 - name: "4.5.2.2 | Ensure root user umask is configured"
-  when: "'4.5.2.2' not in active_exceptions"
+  when: "'4.5.2.2' not in active_exclusions"
   tags: [rule_4.5.2.2, level1, section_4, manual]
   block:
 
@@ -2084,7 +2084,7 @@
 # ---
 
 - name: "4.5.2.3 | Ensure system accounts are secured"
-  when: "'4.5.2.3' not in active_exceptions"
+  when: "'4.5.2.3' not in active_exclusions"
   tags: [rule_4.5.2.3, level1, section_4, manual]
   block:
 
@@ -2141,7 +2141,7 @@
 
 - name: "4.5.3.1 | Ensure nologin is not listed in /etc/shells"
   when:
-    - "'4.5.3.1' not in active_exceptions"
+    - "'4.5.3.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_4.5.3.1, level2, section_4, manual]
   block:
@@ -2173,7 +2173,7 @@
 # ---
 
 - name: "4.5.3.2 | Ensure default user umask is configured"
-  when: "'4.5.3.2' not in active_exceptions"
+  when: "'4.5.3.2' not in active_exclusions"
   tags: [rule_4.5.3.2, level1, section_4, manual]
   block:
 

--- a/tasks/section_5.yml
+++ b/tasks/section_5.yml
@@ -10,7 +10,7 @@
 # =============================================================
 
 - name: "5.1.1.1 | Ensure syslog is installed"
-  when: "'5.1.1.1' not in active_exceptions"
+  when: "'5.1.1.1' not in active_exclusions"
   tags: [rule_5.1.1.1, level1, section_5, manual]
   block:
     - name: "5.1.1.1 | AUDIT | Check syslogd binary and rc.d script are present"
@@ -41,7 +41,7 @@
 # ---
 
 - name: "5.1.1.2 | Ensure syslogd service is enabled"
-  when: "'5.1.1.2' not in active_exceptions"
+  when: "'5.1.1.2' not in active_exclusions"
   tags: [rule_5.1.1.2, level1, section_5, automated]
   block:
     - name: "5.1.1.2 | AUDIT | Check syslogd_enable rc.conf setting"
@@ -69,7 +69,7 @@
 # ---
 
 - name: "5.1.1.3 | Ensure syslogd default file permissions are configured"
-  when: "'5.1.1.3' not in active_exceptions"
+  when: "'5.1.1.3' not in active_exclusions"
   tags: [rule_5.1.1.3, level1, section_5, manual]
   block:
     - name: "5.1.1.3 | AUDIT | Check /etc/newsyslog.conf exists"
@@ -111,7 +111,7 @@
 # ---
 
 - name: "5.1.1.4 | Ensure logging is configured"
-  when: "'5.1.1.4' not in active_exceptions"
+  when: "'5.1.1.4' not in active_exclusions"
   tags: [rule_5.1.1.4, level1, section_5, manual]
   block:
     - name: "5.1.1.4 | AUDIT | List syslog.conf files present"
@@ -157,7 +157,7 @@
 # ---
 
 - name: "5.1.1.5 | Ensure syslog is configured to send logs to a remote log host"
-  when: "'5.1.1.5' not in active_exceptions"
+  when: "'5.1.1.5' not in active_exclusions"
   tags: [rule_5.1.1.5, level1, section_5, manual]
   block:
     # --- Detection: syslog @remote entries ---
@@ -282,7 +282,7 @@
 # ---
 
 - name: "5.1.1.6 | Ensure rsyslog is not configured to receive logs from a remote client"
-  when: "'5.1.1.6' not in active_exceptions"
+  when: "'5.1.1.6' not in active_exclusions"
   tags: [rule_5.1.1.6, level1, section_5, manual]
   block:
     - name: "5.1.1.6 | AUDIT | Check syslogd_flags for -s flag"
@@ -325,7 +325,7 @@
 # =============================================================
 
 - name: "5.1.2 | Ensure newsyslog is configured"
-  when: "'5.1.2' not in active_exceptions"
+  when: "'5.1.2' not in active_exclusions"
   tags: [rule_5.1.2, level1, section_5, manual]
   block:
     - name: "5.1.2 | AUDIT | Check newsyslog.conf exists"
@@ -348,7 +348,7 @@
 # =============================================================
 
 - name: "5.1.3 | Ensure all logfiles have appropriate access configured"
-  when: "'5.1.3' not in active_exceptions"
+  when: "'5.1.3' not in active_exclusions"
   tags: [rule_5.1.3, level1, section_5, manual]
   block:
 
@@ -441,7 +441,7 @@
 
 - name: "5.2.1.1 | Ensure auditd service is enabled"
   when:
-    - "'5.2.1.1' not in active_exceptions"
+    - "'5.2.1.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.1.1, level2, section_5, manual]
   block:
@@ -474,7 +474,7 @@
 
 - name: "5.2.2.1 | Ensure audit log storage size is configured"
   when:
-    - "'5.2.2.1' not in active_exceptions"
+    - "'5.2.2.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.2.1, level2, section_5, manual]
   block:
@@ -509,7 +509,7 @@
 
 - name: "5.2.2.2 | Ensure audit logs are not automatically deleted"
   when:
-    - "'5.2.2.2' not in active_exceptions"
+    - "'5.2.2.2' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.2.2, level2, section_5, manual]
   block:
@@ -546,7 +546,7 @@
 
 - name: "5.2.3.1 | Ensure actions as another user are always logged"
   when:
-    - "'5.2.3.1' not in active_exceptions"
+    - "'5.2.3.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.1, level2, section_5, manual]
   block:
@@ -606,7 +606,7 @@
 
 - name: "5.2.3.2 | Ensure events that modify the sudo log file are collected"
   when:
-    - "'5.2.3.2' not in active_exceptions"
+    - "'5.2.3.2' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.2, level2, section_5, manual]
   block:
@@ -671,7 +671,7 @@
 
 - name: "5.2.3.3 | Ensure use of privileged commands are collected"
   when:
-    - "'5.2.3.3' not in active_exceptions"
+    - "'5.2.3.3' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.3, level2, section_5, manual]
   block:
@@ -731,7 +731,7 @@
 
 - name: "5.2.3.4 | Ensure discretionary access control permission modification events are collected"
   when:
-    - "'5.2.3.4' not in active_exceptions"
+    - "'5.2.3.4' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.4, level2, section_5, manual]
   block:
@@ -791,7 +791,7 @@
 
 - name: "5.2.3.5 | Ensure successful file system mounts are collected"
   when:
-    - "'5.2.3.5' not in active_exceptions"
+    - "'5.2.3.5' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.5, level2, section_5, manual]
   block:
@@ -851,7 +851,7 @@
 
 - name: "5.2.3.6 | Ensure login and logout events are collected"
   when:
-    - "'5.2.3.6' not in active_exceptions"
+    - "'5.2.3.6' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.6, level2, section_5, manual]
   block:
@@ -911,7 +911,7 @@
 
 - name: "5.2.3.7 | Ensure file deletion events by users are collected"
   when:
-    - "'5.2.3.7' not in active_exceptions"
+    - "'5.2.3.7' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.7, level2, section_5, manual]
   block:
@@ -971,7 +971,7 @@
 
 - name: "5.2.3.8 | Ensure successful and unsuccessful attempts to use the usermod command are recorded"
   when:
-    - "'5.2.3.8' not in active_exceptions"
+    - "'5.2.3.8' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.3.8, level2, section_5, manual]
   block:
@@ -1033,7 +1033,7 @@
 
 - name: "5.2.4.1 | Ensure the audit log directory is 0750 or more restrictive"
   when:
-    - "'5.2.4.1' not in active_exceptions"
+    - "'5.2.4.1' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.1, level2, section_5, manual]
   block:
@@ -1103,7 +1103,7 @@
 
 - name: "5.2.4.2 | Ensure audit log files are mode 0640 or less permissive"
   when:
-    - "'5.2.4.2' not in active_exceptions"
+    - "'5.2.4.2' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.2, level2, section_5, manual]
   block:
@@ -1181,7 +1181,7 @@
 
 - name: "5.2.4.3 | Ensure only authorized users own audit log files"
   when:
-    - "'5.2.4.3' not in active_exceptions"
+    - "'5.2.4.3' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.3, level2, section_5, manual]
   block:
@@ -1254,7 +1254,7 @@
 
 - name: "5.2.4.4 | Ensure only authorized groups are assigned ownership of audit log files"
   when:
-    - "'5.2.4.4' not in active_exceptions"
+    - "'5.2.4.4' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.4, level2, section_5, manual]
   block:
@@ -1332,7 +1332,7 @@
 
 - name: "5.2.4.5 | Ensure audit configuration files are restrictive"
   when:
-    - "'5.2.4.5' not in active_exceptions"
+    - "'5.2.4.5' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.5, level2, section_5, manual]
   block:
@@ -1431,7 +1431,7 @@
 
 - name: "5.2.4.6 | Ensure audit configuration files are owned by root"
   when:
-    - "'5.2.4.6' not in active_exceptions"
+    - "'5.2.4.6' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.6, level2, section_5, manual]
   block:
@@ -1462,7 +1462,7 @@
 
 - name: "5.2.4.7 | Ensure audit configuration files belong to group wheel"
   when:
-    - "'5.2.4.7' not in active_exceptions"
+    - "'5.2.4.7' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.7, level2, section_5, manual]
   block:
@@ -1493,7 +1493,7 @@
 
 - name: "5.2.4.8 | Ensure audit tools are 555 or more restrictive"
   when:
-    - "'5.2.4.8' not in active_exceptions"
+    - "'5.2.4.8' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.8, level2, section_5, manual]
   block:
@@ -1528,7 +1528,7 @@
 
 - name: "5.2.4.9 | Ensure audit tools are owned by root"
   when:
-    - "'5.2.4.9' not in active_exceptions"
+    - "'5.2.4.9' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.9, level2, section_5, manual]
   block:
@@ -1563,7 +1563,7 @@
 
 - name: "5.2.4.10 | Ensure audit tools belong to group wheel"
   when:
-    - "'5.2.4.10' not in active_exceptions"
+    - "'5.2.4.10' not in active_exclusions"
     - freebsd_cis_level | int >= 2
   tags: [rule_5.2.4.10, level2, section_5, manual]
   block:
@@ -1599,7 +1599,7 @@
 # =============================================================
 
 - name: "5.3.1 | Ensure AIDE is installed"
-  when: "'5.3.1' not in active_exceptions"
+  when: "'5.3.1' not in active_exclusions"
   tags: [rule_5.3.1, level1, section_5, manual]
   block:
     - name: "5.3.1 | AUDIT | Check if aide package is installed"
@@ -1715,7 +1715,7 @@
 # ---
 
 - name: "5.3.2 | Ensure filesystem integrity is regularly checked"
-  when: "'5.3.2' not in active_exceptions"
+  when: "'5.3.2' not in active_exclusions"
   tags: [rule_5.3.2, level1, section_5, manual]
   block:
     - name: "5.3.2 | AUDIT | Check root crontab for aide --check or --update"  # noqa: risky-shell-pipe

--- a/tasks/section_6.yml
+++ b/tasks/section_6.yml
@@ -14,7 +14,7 @@
   # Benchmark divergence: the remediation says 'chown root:root /etc/passwd'
   # but the Audit expected output and Default Value both show Gid: (0/wheel).
   # FreeBSD convention is root:wheel. We use root:wheel and note the error.
-  when: "'6.1.1' not in active_exceptions"
+  when: "'6.1.1' not in active_exclusions"
   tags: [rule_6.1.1, level1, section_6, automated]
   block:
 
@@ -63,7 +63,7 @@
 # ---
 
 - name: "6.1.2 | Ensure permissions on /etc/group are configured"
-  when: "'6.1.2' not in active_exceptions"
+  when: "'6.1.2' not in active_exclusions"
   tags: [rule_6.1.2, level1, section_6, automated]
   block:
 
@@ -112,7 +112,7 @@
 # ---
 
 - name: "6.1.3 | Ensure permissions on /etc/master.passwd are configured"
-  when: "'6.1.3' not in active_exceptions"
+  when: "'6.1.3' not in active_exclusions"
   tags: [rule_6.1.3, level1, section_6, automated]
   block:
 
@@ -161,7 +161,7 @@
 # ---
 
 - name: "6.1.4 | Ensure permissions on /etc/shells are configured"
-  when: "'6.1.4' not in active_exceptions"
+  when: "'6.1.4' not in active_exclusions"
   tags: [rule_6.1.4, level1, section_6, automated]
   block:
 
@@ -216,7 +216,7 @@
   # World-writable file remediation is NOT automated — removing o-w from unknown
   # files can break applications. Directories are remediated (sticky bit added,
   # world-write removed) because that only restricts deletion, not file access.
-  when: "'6.1.5' not in active_exceptions"
+  when: "'6.1.5' not in active_exclusions"
   tags: [rule_6.1.5, level1, section_6, manual]
   block:
 
@@ -285,7 +285,7 @@
   # Note: -xdev limits the scan to the root filesystem. Files on separately
   # mounted filesystems (/home, /var, /usr) are not checked. This matches
   # the benchmark's audit command but the scope limitation should be noted.
-  when: "'6.1.6' not in active_exceptions"
+  when: "'6.1.6' not in active_exclusions"
   tags: [rule_6.1.6, level1, section_6, manual]
   block:
 
@@ -320,7 +320,7 @@
 # ---
 
 - name: "6.1.7 | Ensure SUID and SGID files are reviewed"
-  when: "'6.1.7' not in active_exceptions"
+  when: "'6.1.7' not in active_exclusions"
   tags: [rule_6.1.7, level1, section_6, manual]
   block:
 
@@ -390,7 +390,7 @@
   # security risk and is checked in 6.2.2. Implementing as-written for
   # benchmark compliance; the conceptual mismatch should be corrected in a
   # future benchmark version.
-  when: "'6.2.1' not in active_exceptions"
+  when: "'6.2.1' not in active_exclusions"
   tags: [rule_6.2.1, level1, section_6, manual]
   block:
 
@@ -448,7 +448,7 @@
   # field is $2 == "" (empty string), which allows passwordless login.
   # We check $2 == "" to match the description's stated intent. This divergence
   # should be corrected in a future benchmark version.
-  when: "'6.2.2' not in active_exceptions"
+  when: "'6.2.2' not in active_exclusions"
   tags: [rule_6.2.2, level1, section_6, manual]
   block:
 
@@ -497,7 +497,7 @@
 # ---
 
 - name: "6.2.3 | Ensure all groups in /etc/passwd exist in /etc/group"
-  when: "'6.2.3' not in active_exceptions"
+  when: "'6.2.3' not in active_exclusions"
   tags: [rule_6.2.3, level1, section_6, manual]
   block:
 
@@ -539,8 +539,8 @@
   # FreeBSD note: FreeBSD ships with a 'toor' account at UID 0 by design.
   # This is intended to allow a third-party shell for root. If toor is the
   # only duplicate UID 0 entry and your site policy permits it, exception-list
-  # this control with '6.2.4' in freebsd_cis_local_exceptions.
-  when: "'6.2.4' not in active_exceptions"
+  # this control with '6.2.4' in freebsd_cis_local_exclusions.
+  when: "'6.2.4' not in active_exclusions"
   tags: [rule_6.2.4, level1, section_6, manual]
   block:
 
@@ -583,7 +583,7 @@
 # ---
 
 - name: "6.2.5 | Ensure no duplicate GIDs exist"
-  when: "'6.2.5' not in active_exceptions"
+  when: "'6.2.5' not in active_exclusions"
   tags: [rule_6.2.5, level1, section_6, manual]
   block:
 
@@ -623,7 +623,7 @@
 # ---
 
 - name: "6.2.6 | Ensure no duplicate user names exist"
-  when: "'6.2.6' not in active_exceptions"
+  when: "'6.2.6' not in active_exclusions"
   tags: [rule_6.2.6, level1, section_6, manual]
   block:
 
@@ -664,7 +664,7 @@
 # ---
 
 - name: "6.2.7 | Ensure no duplicate group names exist"
-  when: "'6.2.7' not in active_exceptions"
+  when: "'6.2.7' not in active_exclusions"
   tags: [rule_6.2.7, level1, section_6, manual]
   block:
 
@@ -703,7 +703,7 @@
 # ---
 
 - name: "6.2.8 | Ensure root path integrity"
-  when: "'6.2.8' not in active_exceptions"
+  when: "'6.2.8' not in active_exclusions"
   tags: [rule_6.2.8, level1, section_6, manual]
   block:
 
@@ -780,8 +780,8 @@
   # root shell with a third-party shell binary). This control will always
   # report NON-COMPLIANT on a stock FreeBSD install unless toor is removed.
   # If your site policy retains toor, exception-list this control with
-  # '6.2.9' in freebsd_cis_local_exceptions.
-  when: "'6.2.9' not in active_exceptions"
+  # '6.2.9' in freebsd_cis_local_exclusions.
+  when: "'6.2.9' not in active_exclusions"
   tags: [rule_6.2.9, level1, section_6, manual]
   block:
 
@@ -822,7 +822,7 @@
   # user, or creating a home directory — decisions that cannot be automated
   # safely. Tagging as manual and reporting only. Future benchmark versions
   # should correct the automated label.
-  when: "'6.2.10' not in active_exceptions"
+  when: "'6.2.10' not in active_exclusions"
   tags: [rule_6.2.10, level1, section_6, manual]
   block:
 
@@ -886,7 +886,7 @@
   # users' files without alerting the user community can result in unexpected
   # outages." Tagging as manual. Future benchmark versions should correct the
   # automated label.
-  when: "'6.2.11' not in active_exceptions"
+  when: "'6.2.11' not in active_exclusions"
   tags: [rule_6.2.11, level1, section_6, manual]
   block:
 

--- a/tasks/section_6.yml
+++ b/tasks/section_6.yml
@@ -538,7 +538,7 @@
 - name: "6.2.4 | Ensure no duplicate UIDs exist"
   # FreeBSD note: FreeBSD ships with a 'toor' account at UID 0 by design.
   # This is intended to allow a third-party shell for root. If toor is the
-  # only duplicate UID 0 entry and your site policy permits it, exception-list
+  # only duplicate UID 0 entry and your site policy permits it, exclude
   # this control with '6.2.4' in freebsd_cis_local_exclusions.
   when: "'6.2.4' not in active_exclusions"
   tags: [rule_6.2.4, level1, section_6, manual]
@@ -779,7 +779,7 @@
   # FreeBSD note: FreeBSD ships with 'toor' at UID 0 by design (provides a
   # root shell with a third-party shell binary). This control will always
   # report NON-COMPLIANT on a stock FreeBSD install unless toor is removed.
-  # If your site policy retains toor, exception-list this control with
+  # If your site policy retains toor, exclude this control with
   # '6.2.9' in freebsd_cis_local_exclusions.
   when: "'6.2.9' not in active_exclusions"
   tags: [rule_6.2.9, level1, section_6, manual]


### PR DESCRIPTION
## Summary

Renames the exception model variables and all related prose to use `exclusion` terminology throughout the role.

Closes #36

## Why

"Accepted" and "excepted" are acoustically identical in fast speech, creating persistent ambiguity in verbal and written communication. "Excluded" is unambiguous in every context and maps more naturally to the operator mental model.

## Changes

**Functional renames (breaking for callers):**

| Old | New |
|---|---|
| `freebsd_cis_global_exceptions` | `freebsd_cis_global_exclusions` |
| `freebsd_cis_local_exceptions` | `freebsd_cis_local_exclusions` |
| `active_exceptions` | `active_exclusions` |

**Three commits:**
1. `chore: rename *_exceptions vars to *_exclusions in tasks and defaults` — 194 occurrences across `tasks/section_{1-6}.yml`, `tasks/main.yml`, `defaults/main.yml`
2. `chore: fix missed task name strings in main.yml` — two task `name:` strings in the orchestrator
3. `chore: rename exception -> exclusion in docs and instructions` — prose and headings in `docs/`, `README.md`, `.github/`

`"Runtime crash or exception"` in `copilot-review-instructions.md` is preserved (programming term, not role terminology).

## Validation

- Pre-commit hooks passed on both YAML commits (ansible-lint production profile, syntax check)
- Full grep sweep across tracked repository paths in this PR confirmed zero remaining `*_exceptions` / `active_exceptions` occurrences in scope
- Functional test by operator confirmed the renamed variables work correctly

## Risks and follow-ups

- **Breaking change** for any playbook or `host_vars` that sets `freebsd_cis_global_exceptions` or `freebsd_cis_local_exceptions` — those must be renamed to `_exclusions`. Old names silently fall back to an empty list.
- No backward-compat shim is provided; the rename is intentional and the variable names were not yet in wide use.
